### PR TITLE
fix(cashew): suppress sentence-transformers INFO noise

### DIFF
--- a/plugins/memory/cashew/__init__.py
+++ b/plugins/memory/cashew/__init__.py
@@ -50,6 +50,14 @@ from .tools import (  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
+# Issue #18: sentence-transformers emits INFO-level progress bars and BertModel
+# load reports directly to the terminal during embedding. That noise leaks into
+# the Hermes UI and looks like broken output. Raise its logger to WARNING once
+# at module load so every embed_text / end_session call downstream stays quiet.
+# Leaves WARNING/ERROR from sentence_transformers untouched so real failures
+# (e.g. model file missing) still surface.
+logging.getLogger("sentence_transformers").setLevel(logging.WARNING)
+
 
 _SHUTDOWN = object()
 """Unique sentinel for graceful sync worker exit.


### PR DESCRIPTION
## Summary
Raise the `sentence_transformers` logger to WARNING at plugin import time so memory save/recall no longer leaks embedding progress bars and BertModel LOAD REPORT tables into the Hermes UI.

## Why this matters
Issue #18 showed the exact UI breakage - `tqdm` progress bars and an ASCII-table `LOAD REPORT` printed directly to the terminal during `cashew_query` / `cashew_extract` calls, which makes the agent output look corrupt. The noise comes from `sentence_transformers` at INFO level inside `embed_text()` (called from `_get_query_embedding`, line 485-493) and inside `end_session()` (called from `_drain_once`, line 684-699 and `cashew_extract` tool, line 896-902).

## Changes
- `plugins/memory/cashew/__init__.py`: one-line `logging.getLogger("sentence_transformers").setLevel(logging.WARNING)` added right after the local `logger = logging.getLogger(__name__)` definition (line 51), plus a 5-line comment pointing at the issue and explaining the trade-off.

The issue proposed a localized fix at each of the three call sites. Setting the logger level once at module import is equivalent and less invasive - the three call-site changes collapse to one line, and there's no risk of one of them drifting out of sync with the others as the plugin grows. `setLevel` is idempotent, so repeat imports during test or plugin-reload cycles stay safe.

Only INFO is suppressed. WARNING and ERROR from `sentence_transformers` still surface, so real failures (model download failure, unsupported revision, device-OOM) are unaffected.

## Testing
```
$ python3 -c "
import logging
st = logging.getLogger('sentence_transformers')
print('before:', logging.getLevelName(st.level))
from plugins.memory import cashew  # noqa
print('after:', logging.getLevelName(st.level))
"
before: NOTSET
after: WARNING
```

Fixes #18

This contribution was developed with AI assistance (Claude Code).
