### PR TITLE
docs: update AGENTS.md with current project state and conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,89 +4,107 @@
 
 Hermes Agent memory provider plugin backed by Cashew (local SQLite knowledge graph with embeddings). Repo root also serves as `$HERMES_HOME/plugins/cashew/` after `hermes plugins install`.
 
-## Repo Layout (non-obvious)
+Thin adapter around upstream [cashew-brain](https://github.com/rajkripal/cashew) — the plugin delegates retrieval, schema management, and LLM operations to upstream. Custom code is limited to Hermes integration surface (config, tools, threading).
 
-- `__init__.py` (root) — thin re-export shim; satisfies the flat-entry loader path. **Do not import Cashew dependencies here.**
-- `plugins/memory/cashew/__init__.py` — real implementation (CashewMemoryProvider + register).
-- `plugins/memory/cashew/config.py` — pure config helpers, zero Hermes/Cashew coupling.
+## Current State (v0.4.0)
+
+- **LLM integration**: `llm_aux_role` config key references `auxiliary.<role>` in Hermes `config.yaml`. Plugin reads Hermes config, resolves credentials, wires `model_fn` callable to upstream. No API keys in plugin config.
+- **Retrieval**: Three-tier (sqlite-vec → BFS → keyword), delegated to upstream `retrieve_recursive_bfs()`.
+- **Schema**: Upstream `core.db.ensure_schema()` — no custom migration layer.
+- **Threading**: Bounded `queue.Queue(maxsize=16)` + single non-daemon worker. Sentinel is `_SHADOW = object()`.
+- **Open issues**: 1 remaining — #15 (privacy / exclude_tags passthrough).
+
+## Project Conventions
+
+### Open Source
+
+This is a public open source project. All contributions must follow:
+
+- **CONTRIBUTING.md** — DCO sign-off (`git commit -s`), Conventional Commits, PR process
+- **Branch from `main`**, open a PR, get review, merge. No direct pushes to main for features.
+- **One PR per logical change.** Don't mix bugfixes with refactoring with features.
+- **Run tests locally** before pushing (`pytest` — must be green or pre-existing failures only).
+- **Issue templates** for bug reports and feature requests.
+
+### Pull Requests
+
+```bash
+git checkout -b fix/description   # or feat/, refactor/, docs/, ci/
+git add <files>
+git commit -s -m "type(scope): description"
+git push -u origin HEAD
+# Open PR via GitHub UI or gh CLI
+```
+
+### Release Process
+
+Releases are triggered by pushing a `v*` tag. The release workflow gates on tests passing, builds the wheel, and publishes to PyPI via trusted publishing.
+
+```bash
+# After PR is merged to main:
+git checkout main && git pull
+# Update version in pyproject.toml and CHANGELOG.md
+git commit -s -m "chore: bump to vX.Y.Z"
+git tag vX.Y.Z && git push origin main --tags
+# Create GitHub Release with notes:
+gh release create vX.Y.Z --title "vX.Y.Z — Title" --notes "..."
+```
+
+The `auxiliary.memory` convention is designed for any Hermes memory provider. When adding features, prefer delegation to upstream over reimplementation.
+
+## Repo Layout
+
+- `__init__.py` (root) — thin re-export shim; flat-entry loader path. **Do not import Cashew dependencies here.**
+- `plugins/memory/cashew/__init__.py` — provider implementation (CashewMemoryProvider + register).
+- `plugins/memory/cashew/config.py` — CashewConfig dataclass, DEFAULTS, load/save, schema (31 keys).
 - `plugins/memory/cashew/tools.py` — JSON envelope builders for tool call responses.
 - `plugins/memory/cashew/plugin.yaml` — bundled-loader hook manifest (hooks: [on_session_end]).
 - `plugin.yaml` (root) — `hermes plugins install` manifest, must stay in sync with the above.
-- `tests/` — pytest, uses a MemoryManager stub and a fake `agent.memory_provider` ABC injected into `sys.modules`.
-- `.github/workflows/tests.yml` — **do not rename**; filename is locked for Phase 5 trusted-publisher config.
+- `tests/` — pytest, MemoryManager stub + fake `agent.memory_provider` ABC in `sys.modules`.
+- `.github/workflows/tests.yml` — **do not rename**; filename locked for trusted-publisher config.
+- `.github/workflows/release.yml` — **do not rename**; OIDC bound to filename.
+- `.planning/` — historical GSD workflow artifacts from v0.1/v0.2 development. Schematic reference only; current work is tracked in GitHub issues.
 
-`plugins/` and `plugins/memory/` are PEP 420 namespace packages (no `__init__.py`).
+`plugins/` and `plugins/memory/` are PEP 420 namespace packages — do NOT add `__init__.py`.
 
 ## Key Constraints
 
 - **No `~/.hermes` writes.** All paths scope under `hermes_home`. Tests use `tmp_path` fixture.
-- **`sync_turn` must return <10 ms.** Uses a bounded `queue.Queue(maxsize=16)` drained by a **non-daemon** worker thread. Sentinel is `_SHUTDOWN = object()`, not `None`.
-- **Cashew dependency on PyPI** (`cashew-brain>=1.1.0,<2.0.0`).
-- **`HF_HUB_OFFLINE=1` etc. are process-wide.** Set in `conftest.py` before any Cashew import. Tests must never trigger the ~500 MB embedding model download.
+- **`sync_turn` must return <10 ms.** Bounded queue + non-daemon worker.
+- **Cashew dependency**: `cashew-brain>=1.1.0,<2.0.0` on PyPI.
+- **`HF_HUB_OFFLINE=1`** set in `conftest.py` before any Cashew import. Embedding model must be mocked in tests.
+- **`CASHEW_*` env vars stripped** in `conftest.py` to prevent Hermes session leak into tests.
+- **Silent degrade** on all Cashew failures — log WARNING, return empty, never raise into Hermes.
 
 ## Developer Commands
 
 ```bash
-pip install -e ".[dev]"       # install with dev deps
-pytest                         # full suite
-pytest tests/test_name.py -xvs  # single file
-python3 -m pytest              # macOS fallback
+pip install -e ".[dev]"                # install with dev deps
+pytest                                 # full suite
+pytest tests/test_name.py -xvs          # single file
+python3 -m pytest                       # macOS fallback
 ```
 
-### Dev Install Quirks (pip install -e .)
+### Dev Install Quirks
 
-Hermes runs from its own venv at `~/.hermes/hermes-agent/venv/`. A dev install must be done
-in *that* venv, and a symlink is needed because Hermes inserts `~/.hermes/hermes-agent/`
-at the front of `sys.path` (hermes_cli/main.py:107), making its `plugins/__init__.py` a
-regular package that blocks PEP 420 namespace resolution for `pip install -e .`.
+Hermes runs from `~/.hermes/hermes-agent/venv/`. For dev installs in that venv, a symlink is needed:
 
 ```bash
-# 1. Install into Hermes venv
 ~/.hermes/hermes-agent/venv/bin/python3 -m pip install -e ".[dev]"
-
-# 2. Symlink so import resolves within Hermes' regular plugins tree
-ln -sf "$PWD/plugins/memory/cashew" \
-       ~/.hermes/hermes-agent/plugins/memory/cashew
+ln -sf "$PWD/plugins/memory/cashew" ~/.hermes/hermes-agent/plugins/memory/cashew
 ```
 
-Without the symlink, the entry-point loader (`ep.load()` → `import plugins.memory.cashew`)
-fails with `ModuleNotFoundError`. End users who install via `hermes plugins install` are
-not affected — that path clones to `$HERMES_HOME/plugins/cashew/` and uses directory-based
-loading, which bypasses the entry point entirely.
+End users who install via `hermes plugins install` are not affected — directory-based loading bypasses the entry point.
 
-CI runs `pytest -xvs` with `HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 HF_DATASETS_OFFLINE=1`. A log-scan step fails if `Downloading.*MiniLM` appears.
+CI runs `pytest -xvs` with `HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 HF_DATASETS_OFFLINE=1`. Log-scan fails if `Downloading.*MiniLM` appears.
 
-## Threading Rule
+## LLM Integration
 
-`sync_turn()` enqueues and returns immediately. The worker calls `core.session.end_session` per turn. On Cashew failure the worker logs `WARNING` with `exc_info=True` and continues. `shutdown()` posts the sentinel, bounded-joins the worker (timeout = `sync_queue_timeout`, default 30s), and **never raises**.
+The plugin supports optional LLM-powered extraction via Hermes' auxiliary model infrastructure:
 
-## Cashew Integration
+- Config key: `llm_aux_role` in `cashew.json` (default: `None` → heuristic-only)
+- User config: `auxiliary.memory` section in Hermes `config.yaml`
+- Plugin reads Hermes config, resolves API key from config or well-known env var, constructs OpenAI-compatible callable
+- Both `_drain_once` (sync worker) and `cashew_extract` (tool) pass the callable to upstream
 
-```python
-from core.context import ContextRetriever
-retriever = ContextRetriever(db_path=str(db_path))  # lazy init
-nodes = retriever.retrieve(query, max_nodes=5)      # sync
-context = retriever.format_context(nodes)            # sync
-```
-
-`ContextRetriever` is a lazy import; `core.context` and `core.session` are also lazily imported inside methods to keep the module loadable for wheel-smoke and discovery when cashew-brain is absent.
-
-## Config
-
-Four keys: `cashew_db_path` (relative, default `cashew/brain.db`), `embedding_model`, `recall_k`, `sync_queue_timeout`. Stored at `$HERMES_HOME/cashew.json`. Absolute paths in `cashew_db_path` are rejected (profile isolation).
-
-## What Not to Touch
-
-- `.planning/` — GSD workflow artifacts, not source code.
-- `tests/__pycache__/` — generated bytecode.
-- `pyproject.toml`'s `allow-direct-references = true` flag — required because of the git+SHA dep; removing it breaks Phase 1 CI.
-
-## graphify
-
-This project has a graphify knowledge graph at graphify-out/.
-
-Rules:
-- Before answering architecture or codebase questions, read graphify-out/GRAPH_REPORT.md for god nodes and community structure
-- If graphify-out/wiki/index.md exists, navigate it instead of reading raw files
-- For cross-module "how does X relate to Y" questions, prefer `graphify query "<question>"`, `graphify path "<A>" "<B>"`, or `graphify explain "<concept>"` over grep — these traverse the graph's EXTRACTED + INFERRED edges instead of scanning files
-- After modifying code files in this session, run `graphify update .` to keep the graph current (AST-only, no API cost)
+See README.md for setup guide, CHANGELOG.md for release history, and CONTRIBUTING.md for contribution guidelines.


### PR DESCRIPTION
Replaces stale GSD-era content with accurate v0.4.0 state:

- LLM integration via `auxiliary.memory` convention
- Proper release process: branch → PR → merge → tag → GitHub Release
- Open source contribution conventions (referencing CONTRIBUTING.md)
- Current repo layout with all key files
- Updated constraints (PyPI dep, CASHEW_* env var stripping)
- Dev commands and quirks
- 1 open issue tracked: #15

Closes out the release-process cleanup from the v0.4.0 cycle.