### PR TITLE
docs: update README for v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v0.5.0 (2026-05-12) — Privacy & Visibility
+
+Privacy controls via `exclude_tags` filtering on all retrieval paths.
+The final open issue from the original milestone plan is resolved.
+
+### Added
+
+- **exclude_tags filtering**: `cashew_query` tool accepts optional
+  `exclude_tags` array parameter to filter out tagged nodes from results.
+  Works in both upstream retrieval (`retrieve_recursive_bfs()`) and
+  keyword fallback (SQL `NOT LIKE` exclusion).
+- **Privacy Controls section**: documented in README with use cases
+  (vault:private tagging, domain isolation, declassification).
+
 ## v0.4.0 (2026-05-12) — Brain Operations
 
 LLM integration via `auxiliary.memory` convention. The plugin now

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ that stores conversation context in a local [Cashew](https://github.com/rajkripa
 thought graph with semantic search and automatic context recall. Get from zero to
 a working install in under five minutes.
 
-**v0.4.0** adds LLM-powered extraction, think cycles, and sleep synthesis
-via the `auxiliary.memory` convention — no API keys in plugin config.
+**v0.5.0** adds privacy controls via `exclude_tags` filtering on all retrieval
+paths — integrate with `vault:private` tagging or any custom tag convention.
 
 ## Prerequisites
 
@@ -118,6 +118,23 @@ Expected output shows `Provider: cashew` with `Plugin: installed` and `Status: a
 Both tools are registered automatically when Hermes loads the plugin.
 On each session start, `prefetch()` retrieves relevant context from the graph
 and injects it into the system prompt.
+
+## Privacy Controls (Optional)
+
+Nodes in the thought graph can carry tags. The `cashew_query` tool accepts an
+`exclude_tags` parameter to filter out nodes with specific tags from results:
+
+```json
+{"query": "prior decisions", "exclude_tags": ["vault:private"]}
+```
+
+This works in both the upstream retrieval path (sqlite-vec / BFS) and the
+keyword fallback. Common use cases:
+
+- **Privacy**: Tag sensitive nodes with `vault:private` to exclude them from
+  group or shared contexts
+- **Domain isolation**: Exclude nodes from specific domains during broad queries
+- **Declassification**: Remove exclusion to reveal previously private nodes
 
 ## LLM Integration (Optional)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hermes-cashew"
-version = "0.4.0"
+version = "0.5.0"
 description = "Hermes Agent memory provider plugin backed by Cashew thought-graph memory."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Updates banner to v0.5.0 and adds a new Privacy Controls section documenting the `exclude_tags` parameter, usage examples, and common use cases (vault:private tagging, domain isolation, declassification).