### PR TITLE
feat: run upstream think_cycle() periodically when LLM is wired

### DIFF
--- a/plugins/memory/cashew/__init__.py
+++ b/plugins/memory/cashew/__init__.py
@@ -88,6 +88,7 @@ class CashewMemoryProvider(MemoryProvider):
         # matches the WARNING-log count. See B-02 revision in
         # PHASE_DESIGN_NOTES (2026-04-20).
         self._model_fn: Callable[[str], str] | None = None
+        self._think_counter: int = 0
 
     @property
     def name(self) -> str:
@@ -508,6 +509,25 @@ class CashewMemoryProvider(MemoryProvider):
             conversation_text=f"User: {user}\nAssistant: {assistant}",
             model_fn=self._model_fn,
         )
+        # Run think cycle periodically if LLM is wired
+        if self._model_fn is not None and self._config and self._config.think_interval > 0:
+            self._think_counter += 1
+            if self._think_counter >= self._config.think_interval:
+                self._think_counter = 0
+                try:
+                    from core.session import think_cycle
+                    result = think_cycle(
+                        db_path=str(self._db_path),
+                        model_fn=self._model_fn,
+                    )
+                    if result.new_nodes:
+                        logger.info(
+                            "think cycle produced %d insight(s) on cluster: %s",
+                            len(result.new_nodes),
+                            result.cluster_topic or "unknown",
+                        )
+                except Exception:
+                    logger.warning("think cycle failed", exc_info=True)
 
     def on_session_end(self, messages: list) -> None:
         """Best-effort bounded drain; does NOT stop the worker (ABC-06).

--- a/plugins/memory/cashew/config.py
+++ b/plugins/memory/cashew/config.py
@@ -61,6 +61,7 @@ DEFAULTS: dict[str, Any] = {
     "pattern_detection": True,
     # LLM integration
     "llm_aux_role": None,
+    "think_interval": 10,
 }
 
 
@@ -108,6 +109,7 @@ class CashewConfig:
     pattern_detection: bool = DEFAULTS["pattern_detection"]
     # LLM integration
     llm_aux_role: str | None = DEFAULTS["llm_aux_role"]
+    think_interval: int = DEFAULTS["think_interval"]
 
 
 def _env_var_name(key: str) -> str:
@@ -337,6 +339,17 @@ def get_config_schema() -> list[dict[str, Any]]:
             ),
             "default": DEFAULTS["llm_aux_role"],
             "env_var": _env_var_name("llm_aux_role"),
+        },
+        {
+            "key": "think_interval",
+            "description": (
+                "Number of sync turns between think cycles. When an LLM is "
+                "configured (via llm_aux_role), the plugin runs upstream "
+                "think_cycle() every N turns to discover cross-domain "
+                "connections and generate insight nodes. Set to 0 to disable."
+            ),
+            "default": DEFAULTS["think_interval"],
+            "env_var": _env_var_name("think_interval"),
         },
     ]
     return schema

--- a/tests/test_config_roundtrip.py
+++ b/tests/test_config_roundtrip.py
@@ -30,11 +30,11 @@ from plugins.memory.cashew.config import (
 )
 
 
-EXPECTED_KEY_COUNT = 31
+EXPECTED_KEY_COUNT = 32
 
 
-def test_defaults_contains_exactly_31_keys_with_documented_values():
-    """CONF-01: schema declares all ~31 keys."""
+def test_defaults_contains_exactly_32_keys_with_documented_values():
+    """CONF-01: schema declares all ~32 keys."""
     assert len(DEFAULTS) == EXPECTED_KEY_COUNT
     assert DEFAULTS["cashew_db_path"] == "cashew/brain.db"
     assert DEFAULTS["embedding_model"] == "all-MiniLM-L6-v2"


### PR DESCRIPTION
## Summary

The `think_cycles` config key was cosmetic — upstream `think_cycle()` was never called. This PR wires it: every N sync turns (configurable via `think_interval`, default 10), the plugin calls upstream `think_cycle()` after extraction to discover cross-domain connections and generate insight nodes.

## Changes

- `config.py`: Added `think_interval` config key (default 10, 0 = disabled, 32 total keys)
- `__init__.py`: Added `_think_counter`, periodic `think_cycle()` call in `_drain_once()` after `end_session()`
- Tests: Updated expected key count to 32

## Why 10?

A sync turn fires on every assistant response. In a typical session that's 5-50 turns. think_interval=10 means roughly once per session — frequent enough to be useful, not so frequent it burns API calls on sparse conversations.

## Graceful Degrade

- No LLM configured (`model_fn` is None) → think cycles never fire regardless of interval
- `think_interval=0` → disabled
- Upstream `think_cycle()` fails → warning logged, sync worker continues

## Related Issues

Closes #26

## Test Plan

- [x] Config tests pass (32 keys)
- [x] No regressions in tool/cashew_extract tests
- [x] think_interval=0 skips cycle code path
- [x] No LLM (model_fn=None) skips cycle code path
