### PR TITLE
ci: validate pyproject.toml version matches git tag before building

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,16 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+      - name: Validate version matches tag
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          TAG_VERSION="${TAG_VERSION%%-*}"
+          PACKAGE_VERSION="$(grep -Po '^version = \"\K[^\"]+' pyproject.toml)"
+          if [ "$TAG_VERSION" != "$PACKAGE_VERSION" ]; then
+            echo "::error::Tag version $TAG_VERSION but pyproject.toml says $PACKAGE_VERSION"
+            exit 1
+          fi
+          echo "Version match: v$PACKAGE_VERSION"
       - name: Install build dependencies
         run: pip install build
       - name: Build wheel and sdist


### PR DESCRIPTION
Adds a version validation step to the release workflow that catches the recurring gotcha where a tag was pushed without bumping pyproject.toml first.

Closes #30