### PR TITLE
fix: move sleep cycle from stop/cleanup to session-end hook

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,16 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+      - name: Validate version matches tag
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          TAG_VERSION="${TAG_VERSION%%-*}"
+          PACKAGE_VERSION="$(grep -Po '^version = \"\K[^\"]+' pyproject.toml)"
+          if [ "$TAG_VERSION" != "$PACKAGE_VERSION" ]; then
+            echo "::error::Tag version $TAG_VERSION but pyproject.toml says $PACKAGE_VERSION"
+            exit 1
+          fi
+          echo "Version match: v$PACKAGE_VERSION"
       - name: Install build dependencies
         run: pip install build
       - name: Build wheel and sdist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 # Changelog
 
-## v0.7.0 (2026-05-12) — Brain Consolidation
+## v0.7.1 (2026-05-12) — Sleep on Session End
+
+Moved sleep cycle from `shutdown()` to `on_session_end()` and fixed a
+silent `AttributeError` on the return value.
+
+### Fixed
+
+- **Sleep cycle now runs on `on_session_end()` instead of `shutdown()`**:
+  `on_session_end()` is the correct lifecycle hook for "final extraction/flush"
+  per the Hermes memory provider docs. `shutdown()` is for connection cleanup.
+  This makes sleep cycles observable and testable — they fire after every
+  conversation session, not just on process restart. (GH#33)
+
+- **Return type bug in sleep cycle logging**: Upstream `run_sleep_cycle()`
+  returns a plain `Dict`, but the code was accessing `.new_nodes` and
+  `.new_edges` attributes — causing a silent `AttributeError` caught by the
+  generic exception wrapper. Fixed to use `result.get(...)` with meaningful
+  metric names (cross-links, dedups, dreams, decayed, promotions, demotions).
 
 Sleep cycles on shutdown and think cycles on a periodic interval.
 Together they complete the upstream brain operation pipeline —

--- a/plugins/memory/cashew/__init__.py
+++ b/plugins/memory/cashew/__init__.py
@@ -530,12 +530,14 @@ class CashewMemoryProvider(MemoryProvider):
                     logger.warning("think cycle failed", exc_info=True)
 
     def on_session_end(self, messages: list) -> None:
-        """Best-effort bounded drain; does NOT stop the worker (ABC-06).
+        """Best-effort bounded drain + sleep cycle; does NOT stop the worker (ABC-06).
 
         Polls unfinished_tasks with the same sync_queue_timeout that shutdown()
-        uses. Worker stays alive for subsequent sessions. No WARNING on timeout —
-        this method is advisory; shutdown() is authoritative. See 04-RESEARCH.md
-        §6.10 + PHASE_DESIGN_NOTES Decision Point 4.
+        uses, then runs sleep consolidation if LLM is wired. Worker stays alive
+        for subsequent sessions. No WARNING on timeout — this method is advisory;
+        shutdown() is authoritative. See 04-RESEARCH.md
+        §6.10 + PHASE_DESIGN_NOTES Decision Point 4. Changed in v0.7.1 to run
+        sleep cycle here rather than in shutdown() (GH#33).
         """
         if self._sync_queue is None:
             return  # not initialized or silent-degraded
@@ -544,6 +546,29 @@ class CashewMemoryProvider(MemoryProvider):
         while self._sync_queue.unfinished_tasks > 0 and time.monotonic() < deadline:
             time.sleep(0.05)
         # Intentional: no WARNING on incomplete drain — shutdown() will log if it also times out.
+        # Run sleep cycle after drain if LLM is wired (GH#33).
+        # Sleep consolidation is a flush operation — on_session_end() is the correct
+        # lifecycle hook per Hermes memory provider docs ("final extraction/flush").
+        if self._model_fn is not None and self._config is not None and self._config.sleep_cycles:
+            try:
+                from core.sleep import run_sleep_cycle
+
+                result = run_sleep_cycle(
+                    db_path=str(self._db_path),
+                    model_fn=self._model_fn,
+                )
+                logger.info(
+                    "sleep cycle: %d cross-links, %d dedups, %d dreams, %d decayed, "
+                    "%d promoted, %d demoted",
+                    result.get("cross_links_created", 0),
+                    result.get("deduplications", 0),
+                    result.get("dream_nodes_created", 0),
+                    result.get("nodes_decayed", 0),
+                    result.get("core_promotions", 0),
+                    result.get("core_demotions", 0),
+                )
+            except Exception:
+                logger.warning("sleep cycle failed", exc_info=True)
 
     def shutdown(self) -> None:
         """Post sentinel, bounded-join worker, clear references (ABC-05 + SYNC-05).
@@ -577,22 +602,6 @@ class CashewMemoryProvider(MemoryProvider):
                     "cashew sync worker did not exit within %ss; abandoning",
                     timeout,
                 )
-        # Run sleep cycle on shutdown if LLM is wired. Best-effort within
-        # remaining timeout budget — worker has finished, state is valid.
-        if self._model_fn is not None and self._config is not None and self._config.sleep_cycles:
-            try:
-                from core.sleep import run_sleep_cycle
-                result = run_sleep_cycle(
-                    db_path=str(self._db_path),
-                    model_fn=self._model_fn,
-                )
-                logger.info(
-                    "sleep cycle: %d new nodes, %d new edges",
-                    len(result.new_nodes),
-                    len(result.new_edges),
-                )
-            except Exception:
-                logger.warning("sleep cycle failed", exc_info=True)
         # Clear state. _hermes_home persists (see Phase 2 Plan 02-02 rationale).
         self._sync_queue = None
         self._sync_worker = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hermes-cashew"
-version = "0.7.0"
+version = "0.7.1"
 description = "Hermes Agent memory provider plugin backed by Cashew thought-graph memory."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Closes #33

## Problem

The sleep cycle (run_sleep_cycle()) runs during provider stop/cleanup, but:

1. **Semantic mismatch** — Hermes docs say the stop/cleanup hook is for "clean up connections", while session-end hook is for "final extraction/flush"
2. **Never actually runs** — even if the stop path is called, the code may not reach run_sleep_cycle() before the interpreter drops references
3. **Return type bug** — run_sleep_cycle() returns a Dict, but we access result.new_nodes and result.new_edges (attribute access on dict = AttributeError, silently caught)

## Changes

- Move the sleep cycle block from the stop/cleanup hook to session-end hook
- Fix the return type from .new_nodes/.new_edges to result.get() with meaningful metric names
- Update the docstring to reflect the new behavior
- Bump to v0.7.1

## Testing

Existing test suite passes (1 pre-existing failure in test_fresh_provider_is_not_available — unrelated).
