### PR TITLE
fix(init): detect Hermes 'hermes_plugins' namespace in flat-entry check

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 # __init__.py (repo root — dual-context implementation)
 #
-# FLAT-ENTRY (Hermes): Loaded as _hermes_user_memory.cashew.
-# Python sets __package__ = '_hermes_user_memory' (a non-existent parent).
+# FLAT-ENTRY (Hermes): Loaded as hermes_plugins.cashew (Hermes 0.8.8+) or _hermes_user_memory.cashew older Hermes)
+# Python sets __package__ to the parent namespace (a synthetic module in sys.modules).
 # We detect flat-entry by __spec__.parent not being a real package in sys.modules.
 # We provide the full implementation by pre-populating sys.modules and exec'ing the
 # nested __init__.py so relative imports resolve.
@@ -15,10 +15,10 @@ import importlib.util
 import sys
 import os
 
-# Detect flat-entry: __spec__.parent is '_hermes_user_memory' (no real package).
+# Detect flat-entry: __spec__.parent is a Hermes synthetic namespace (hermes_plugins or _hermes_user_memory).
 # In pip/test, this root __init__.py is NOT loaded (namespace package skips it).
 _spec_parent = getattr(__spec__, "parent", "") or ""
-_is_flat = _spec_parent.startswith("_hermes_user_memory") or _spec_parent.startswith("_hermes")
+_is_flat = _spec_parent.startswith("_hermes_user_memory") or _spec_parent.startswith("_hermes") or _spec_parent == "hermes_plugins"
 
 if _is_flat:
     _root = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
## Summary

Fixes #43 — the root `__init__.py`'s flat-entry detection missed Hermes' `hermes_plugins` namespace, causing the plugin to silently fail registration.

## Problem

Hermes 0.8.8+ loads directory-based user plugins under the `hermes_plugins` synthetic namespace (defined as `_NS_PARENT` in `hermes_cli/plugins.py:172`). The flat-entry condition only checked:

```python
_is_flat = _spec_parent.startswith("_hermes_user_memory") or _spec_parent.startswith("_hermes")
```

Since `"hermes_plugins"` doesn't start with `"_hermes"` (no leading underscore), `_is_flat` was `False`, causing the code to fall through to the `else` branch which tries `from plugins.memory.cashew import ...` — an import path that only works when the package is pip-installed, not when loaded via Hermes' directory loader.

## Fix

Added `or _spec_parent == "hermes_plugins"` to the flat-entry detection condition, and updated the docstring comments to accurately reflect the actual Hermes namespace.

## Testing

- The condition now correctly matches when `__spec__.parent` is `"hermes_plugins"`, `"_hermes_user_memory"`, or any `_hermes*` prefix
- Existing `_hermes_user_memory` and `_hermes` paths are unaffected
- The `else` branch (pip/test via namespace package) is untouched — the root `__init__.py` is not loaded in that path anyway due to PEP 420 namespace resolution

## Release Notes

- Fixed: Root __init__.py now correctly detects Hermes' `hermes_plugins` namespace during flat-entry loading, resolving the "Plugin 'cashew' has no register() function" warning and eliminating the downstream background-review ImportError race condition.
