### PR TITLE
feat: auto-generate cashew.json with defaults on first load

### DIFF
--- a/plugins/memory/cashew/__init__.py
+++ b/plugins/memory/cashew/__init__.py
@@ -62,6 +62,102 @@ signal path. See 04-RESEARCH.md §6.4 for rationale.
 """
 
 
+# ── First-load bootstrap helpers ──────────────────────────────────────
+
+
+def _ensure_config_file(hermes_home: pathlib.Path) -> None:
+    """Write default cashew.json if none exists (first-load bootstrap).
+
+    Uses generate_default_config from config.py which never overwrites
+    an existing file. Safe to call on every initialize() — no-op after
+    the first run.
+    """
+    from .config import generate_default_config
+
+    generate_default_config(hermes_home)
+
+
+def _ensure_auxiliary_memory(hermes_home: pathlib.Path) -> None:
+    """Auto-populate auxiliary.memory in Hermes config.yaml if absent.
+
+    When llm_aux_role="memory" is set (the new default) but the user has
+    no auxiliary.memory section in their Hermes config.yaml, the plugin
+    reads the main model config (provider, model, base_url) and creates an
+    auxiliary.memory section with matching settings. This makes LLM-powered
+    extraction work out of the box without manual config editing.
+
+    Safe to call repeatedly — only writes when auxiliary.memory is absent
+    and the main model config provides usable values. Never overwrites an
+    existing auxiliary.memory section.
+    """
+    config_path = hermes_home / "config.yaml"
+    if not config_path.exists():
+        return
+
+    try:
+        import yaml
+
+        raw = config_path.read_text(encoding="utf-8")
+        data = yaml.safe_load(raw) or {}
+    except Exception:
+        logger.warning(
+            "failed to read %s for auxiliary.memory auto-population",
+            config_path,
+            exc_info=True,
+        )
+        return
+
+    # Don't touch existing auxiliary.memory config
+    aux = data.get("auxiliary", {})
+    if "memory" in aux:
+        return
+
+    model_section = data.get("model", {})
+    provider = model_section.get("provider")
+    default_model = model_section.get("default")
+    base_url = model_section.get("base_url")
+
+    if not provider or not default_model:
+        logger.info(
+            "cannot auto-populate auxiliary.memory: "
+            "model.provider=%r model.default=%r",
+            provider,
+            default_model,
+        )
+        return
+
+    # Build the auxiliary.memory section
+    memory_config: dict[str, str | int] = {
+        "provider": provider,
+        "model": default_model,
+    }
+    if base_url:
+        memory_config["base_url"] = base_url
+
+    if "auxiliary" not in data:
+        data["auxiliary"] = {}
+    data["auxiliary"]["memory"] = memory_config
+
+    try:
+        config_path.write_text(
+            yaml.safe_dump(data, default_flow_style=False, sort_keys=False, allow_unicode=True),
+            encoding="utf-8",
+        )
+        logger.info(
+            "auto-populated auxiliary.memory from main model config: "
+            "provider=%s model=%s",
+            provider,
+            default_model,
+        )
+    except Exception:
+        logger.warning(
+            "failed to write auxiliary.memory to %s",
+            config_path,
+            exc_info=True,
+        )
+
+
+# ── on_pre_compress prompt template ──────────────────────────────────
 class CashewMemoryProvider(MemoryProvider):
     """Cashew thought-graph memory provider for Hermes Agent."""
 
@@ -94,22 +190,31 @@ class CashewMemoryProvider(MemoryProvider):
         return "cashew"
 
     def is_available(self) -> bool:
-        """Return True iff a Cashew config file exists under hermes_home.
+        """Return True iff the provider can be initialized.
 
-        Contract (per ROADMAP Phase 2 Success #3 + Phase 1 RESEARCH.md Pitfall 5):
-        zero I/O beyond ONE Path.exists() probe. No file content is read here.
-        Hermes calls is_available() before initialize using a temporary provider
-        instance — we probe the default config location if _hermes_home has not
-        been set yet.
+        Two-path check:
+        1. Config file exists under hermes_home (legacy fast path)
+        2. Plugin dependencies are importable (first-load path) — if cashew-brain
+           was installed successfully, ContextRetriever was set at module import
+           time, and initialize() will generate defaults on first run.
+
+        The second path ensures a fresh install shows green in `hermes memory
+        status` without requiring manual cashew.json creation.
         """
+        # Fast path: config file exists
         if self._hermes_home is not None:
-            return resolve_config_path(self._hermes_home).exists()
-        # Fallback for pre-initialize check
-        try:
-            from hermes_constants import get_hermes_home
-            return resolve_config_path(get_hermes_home()).exists()
-        except Exception:
-            return False
+            if resolve_config_path(self._hermes_home).exists():
+                return True
+        else:
+            try:
+                from hermes_constants import get_hermes_home  # type: ignore[import-untyped]
+                if resolve_config_path(get_hermes_home()).exists():
+                    return True
+            except Exception:
+                pass
+
+        # Fallback: deps are importable — initialize() will generate defaults
+        return ContextRetriever is not None
 
     def get_config_schema(self) -> Dict[str, Any]:
         """Return the JSON-Schema-shaped dict Hermes uses to drive `hermes memory setup` (CONF-01)."""
@@ -150,6 +255,12 @@ class CashewMemoryProvider(MemoryProvider):
         self._sync_queue = queue.Queue(maxsize=16)
         try:
             self._config = load_config(self._hermes_home)
+            # First-load bootstrap: generate default cashew.json and
+            # auto-populate auxiliary.memory if absent. Safe to call
+            # on every initialize() — no-op after the first run.
+            _ensure_config_file(self._hermes_home)
+            if self._config.llm_aux_role:
+                _ensure_auxiliary_memory(self._hermes_home)
             self._db_path = resolve_db_path(self._hermes_home, self._config.cashew_db_path)
             # Phase 3 eager construction (PHASE_DESIGN_NOTES Decision Point 1).
             # ContextRetriever.__init__ is lazy — no SQLite open, no embedding load yet.
@@ -190,7 +301,6 @@ class CashewMemoryProvider(MemoryProvider):
         )
         self._sync_worker.start()
 
-    # ------------------------------------------------------------------
     # LLM integration via auxiliary.memory convention
     # ------------------------------------------------------------------
 
@@ -224,7 +334,7 @@ class CashewMemoryProvider(MemoryProvider):
 
         config_path = self._hermes_home / "config.yaml" if self._hermes_home else pathlib.Path()
         if not config_path or not config_path.exists():
-            logger.warning(
+            logger.info(
                 "llm_aux_role=%r but %s not found; falling back to heuristic extraction",
                 role, config_path,
             )

--- a/plugins/memory/cashew/config.py
+++ b/plugins/memory/cashew/config.py
@@ -59,8 +59,10 @@ DEFAULTS: dict[str, Any] = {
     "sleep_cycles": True,
     "decay_pruning": True,
     "pattern_detection": True,
-    # LLM integration
-    "llm_aux_role": None,
+    # LLM integration — "memory" activates LLM-powered extraction by default
+    # via auxiliary.memory in Hermes config.yaml. On first load, the plugin
+    # auto-populates auxiliary.memory from the main model config if absent.
+    "llm_aux_role": "memory",
     "think_interval": 10,
 }
 
@@ -108,7 +110,7 @@ class CashewConfig:
     decay_pruning: bool = DEFAULTS["decay_pruning"]
     pattern_detection: bool = DEFAULTS["pattern_detection"]
     # LLM integration
-    llm_aux_role: str | None = DEFAULTS["llm_aux_role"]
+    llm_aux_role: str = DEFAULTS["llm_aux_role"]
     think_interval: int = DEFAULTS["think_interval"]
 
 
@@ -331,11 +333,13 @@ def get_config_schema() -> list[dict[str, Any]]:
         {
             "key": "llm_aux_role",
             "description": (
-                "Hermes auxiliary role to use for LLM-powered operations "
-                "(think cycles, sleep synthesis, LLM extraction). Set to the "
-                "name of an auxiliary.memory section in Hermes config.yaml. "
-                "When unset or null, falls back to heuristic-only extraction "
-                "with no LLM calls."
+                "Hermes auxiliary role for LLM-powered operations "
+                "(think cycles, sleep synthesis, LLM extraction). "
+                "Defaults to 'memory', which reads from auxiliary.memory "
+                "in Hermes config.yaml. The plugin auto-populates "
+                "auxiliary.memory from the main model config on first load "
+                "if absent. Set to null or empty string to disable LLM "
+                "extraction and use heuristic-only mode."
             ),
             "default": DEFAULTS["llm_aux_role"],
             "env_var": _env_var_name("llm_aux_role"),
@@ -435,6 +439,21 @@ def load_config(hermes_home: str | os.PathLike[str]) -> CashewConfig:
     known = {f.name for f in dataclasses.fields(CashewConfig)}
     filtered = {k: v for k, v in merged.items() if k in known}
     return CashewConfig(**filtered)
+
+
+def generate_default_config(hermes_home: str | os.PathLike[str]) -> pathlib.Path:
+    """Write a default cashew.json if none exists.
+
+    Creates the config file at $HERMES_HOME/cashew.json with all DEFAULTS,
+    so subsequent is_available() checks find it. Existing files are never
+    overwritten — this is a one-time bootstrap on first load.
+
+    Returns the path written, or the existing path if file already existed.
+    """
+    path = resolve_config_path(hermes_home)
+    if path.exists():
+        return path
+    return save_config(dict(DEFAULTS), hermes_home)
 
 
 def save_config(values: dict[str, Any], hermes_home: str | os.PathLike[str]) -> pathlib.Path:

--- a/tests/test_config_roundtrip.py
+++ b/tests/test_config_roundtrip.py
@@ -66,6 +66,8 @@ def test_defaults_contains_exactly_32_keys_with_documented_values():
     assert DEFAULTS["sleep_cycles"] is True
     assert DEFAULTS["decay_pruning"] is True
     assert DEFAULTS["pattern_detection"] is True
+    assert DEFAULTS["llm_aux_role"] == "memory"
+    assert DEFAULTS["think_interval"] == 10
 
 
 def test_cashew_config_dataclass_field_set_matches_defaults():

--- a/tests/test_initialize_lifecycle.py
+++ b/tests/test_initialize_lifecycle.py
@@ -16,10 +16,18 @@ from plugins.memory.cashew import CashewMemoryProvider
 from plugins.memory.cashew.config import CashewConfig, DEFAULTS, CONFIG_FILENAME
 
 
-def test_fresh_provider_is_not_available():
-    """ABC-04 + Phase 2 Success #3: pre-initialize, is_available is False unconditionally."""
+def test_fresh_provider_is_not_available_without_deps(monkeypatch):
+    """ABC-04 + Phase 2 Success #3: pre-initialize is False when ContextRetriever unavailable."""
+    from plugins.memory.cashew import ContextRetriever as real_retriever
+    # Simulate no-cashew-brain scenario by nulling ContextRetriever
+    # (as happens at module import when cashew-brain is not installed).
+    import plugins.memory.cashew as cashew_mod
+    monkeypatch.setattr(cashew_mod, "ContextRetriever", None)
     p = CashewMemoryProvider()
+    # Without deps AND without config file, is_available must be False
     assert p.is_available() is False
+    monkeypatch.undo()
+    assert p.is_available() is True, "restored: with deps and no file, should be available"
 
 
 def test_shutdown_pre_initialize_is_safe_noop():
@@ -125,14 +133,31 @@ def test_full_roundtrip_save_then_initialize(tmp_path):
         p.shutdown()
 
 
-def test_is_available_transitions_false_to_true_after_save_config(tmp_path):
-    """Phase 2 Success #3: is_available True iff cashew.json exists under hermes_home."""
+def test_initialize_generates_config_file_on_first_load(tmp_path):
+    """First-load bootstrap: initialize() writes cashew.json when none exists."""
+    p = CashewMemoryProvider()
+    assert not (tmp_path / CONFIG_FILENAME).exists(), "precondition: no config file"
+    p.initialize("s", hermes_home=str(tmp_path))
+    try:
+        assert (tmp_path / CONFIG_FILENAME).exists(), "initialize() must create cashew.json"
+        assert p.is_available() is True, "is_available must be True after file exists"
+    finally:
+        p.shutdown()
+
+
+def test_initialize_does_not_overwrite_existing_config(tmp_path):
+    """First-load bootstrap: existing cashew.json is never overwritten."""
+    existing = {"recall_k": 42, "user_domain": "custom"}
+    (tmp_path / CONFIG_FILENAME).write_text(json.dumps(existing))
     p = CashewMemoryProvider()
     p.initialize("s", hermes_home=str(tmp_path))
     try:
-        assert p.is_available() is False, "no cashew.json yet"
-        p.save_config({}, str(tmp_path))
-        assert p.is_available() is True, "cashew.json now exists"
+        # Verify our custom values survived
+        assert p._config.recall_k == 42
+        assert p._config.user_domain == "custom"
+        # Verify the file wasn't replaced wholesale
+        on_disk = json.loads((tmp_path / CONFIG_FILENAME).read_text())
+        assert on_disk["recall_k"] == 42
     finally:
         p.shutdown()
 
@@ -225,3 +250,67 @@ def test_get_config_schema_returns_helper_module_schema():
     from plugins.memory.cashew.config import get_config_schema as helper_schema
     p = CashewMemoryProvider()
     assert p.get_config_schema() == helper_schema()
+
+
+# ── First-load bootstrap tests ──────────────────────────────────────────
+
+
+def test_ensure_config_file_writes_defaults(tmp_path):
+    """_ensure_config_file writes cashew.json when absent, no-ops when present."""
+    from plugins.memory.cashew import _ensure_config_file
+    assert not (tmp_path / "cashew.json").exists()
+    _ensure_config_file(tmp_path)
+    assert (tmp_path / "cashew.json").exists()
+    # Second call is no-op (file already exists)
+    mtime = (tmp_path / "cashew.json").stat().st_mtime_ns
+    _ensure_config_file(tmp_path)
+    assert (tmp_path / "cashew.json").stat().st_mtime_ns == mtime
+
+
+def test_ensure_auxiliary_memory_populates_from_main_model(tmp_path):
+    """_ensure_auxiliary_memory creates auxiliary.memory from model section."""
+    from plugins.memory.cashew import _ensure_auxiliary_memory
+    config_yaml = tmp_path / "config.yaml"
+    config_yaml.write_text("""model:
+  provider: openrouter
+  default: openrouter/auto
+  base_url: https://openrouter.ai/api/v1
+""")
+    assert not (tmp_path / "cashew.json").exists()
+    _ensure_auxiliary_memory(tmp_path)
+    import yaml
+    data = yaml.safe_load(config_yaml.read_text())
+    aux_memory = data.get("auxiliary", {}).get("memory", {})
+    assert aux_memory["provider"] == "openrouter"
+    assert aux_memory["model"] == "openrouter/auto"
+    assert aux_memory["base_url"] == "https://openrouter.ai/api/v1"
+
+
+def test_ensure_auxiliary_memory_does_not_overwrite_existing(tmp_path):
+    """_ensure_auxiliary_memory never overwrites existing auxiliary.memory."""
+    from plugins.memory.cashew import _ensure_auxiliary_memory
+    config_yaml = tmp_path / "config.yaml"
+    config_yaml.write_text("""model:
+  provider: openrouter
+  default: openrouter/auto
+auxiliary:
+  memory:
+    provider: custom
+    model: custom-model
+""")
+    _ensure_auxiliary_memory(tmp_path)
+    import yaml
+    data = yaml.safe_load(config_yaml.read_text())
+    assert data["auxiliary"]["memory"]["provider"] == "custom"
+    assert data["auxiliary"]["memory"]["model"] == "custom-model"
+
+
+def test_ensure_config_file_called_from_initialize(tmp_path):
+    """initialize() writes cashew.json when none exists."""
+    p = CashewMemoryProvider()
+    assert not (tmp_path / "cashew.json").exists()
+    p.initialize("s", hermes_home=str(tmp_path))
+    try:
+        assert (tmp_path / "cashew.json").exists()
+    finally:
+        p.shutdown()

--- a/tests/test_stub_lifecycle.py
+++ b/tests/test_stub_lifecycle.py
@@ -10,9 +10,17 @@ def test_name_is_cashew():
 
 
 def test_is_available_false_before_config():
-    """ABC-03: is_available returns False with zero I/O before Phase 2 config round-trip."""
-    provider = CashewMemoryProvider()
-    assert provider.is_available() is False
+    """ABC-03: is_available returns False when deps are unavailable and no config exists."""
+    import plugins.memory.cashew as cashew_mod
+    from plugins.memory.cashew import ContextRetriever as real_retriever
+    # Temporarily null ContextRetriever to simulate no-cashew-brain scenario
+    original = cashew_mod.ContextRetriever
+    cashew_mod.ContextRetriever = None
+    try:
+        provider = CashewMemoryProvider()
+        assert provider.is_available() is False
+    finally:
+        cashew_mod.ContextRetriever = original
 
 
 def test_is_available_no_filesystem_calls(monkeypatch):


### PR DESCRIPTION
## Summary

Three changes that make hermes-cashew work out of the box after a clean install — no manual config file creation needed.

### Changes

1. **Auto-generate `cashew.json`** — when `initialize()` finds no config file, it writes one with all 32 DEFAULTS. Subsequent `is_available()` calls find the file and return `True`. Existing configs are never overwritten.

2. **Default `llm_aux_role` to `"memory"`** — activates LLM-powered extraction by default instead of heuristic-only mode. The plugin auto-populates `auxiliary.memory` in Hermes `config.yaml` from the main model config when absent, so extraction works without manual config editing.

3. **Update `is_available()`** — returns `True` when plugin dependencies are importable (cashew-brain installed) even without a config file, since `initialize()` will generate defaults. This makes `hermes memory status` show green immediately after install.

### Testing

- ✅ All 188 existing tests pass (2 skipped — same as before)
- ✅ 5 new tests for first-load bootstrap behavior
- ✅ Verified in isolated venv simulating clean install:
  - `is_available()` returns `True` pre-init with deps present
  - `cashew.json` written to disk with 32 keys and `llm_aux_role='memory'`
  - `auxiliary.memory` auto-populated from main model config
  - Existing config preserved on re-initialize

### Closes

Closes #47