### PR TITLE
fix: sync plugin.yaml versions with pyproject.toml (0.8.2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,13 @@ jobs:
             exit 1
           fi
           echo "Version match: v$PACKAGE_VERSION"
+      - name: Sync plugin.yaml versions to pyproject.toml
+        run: |
+          VERSION="$(grep -Po '^version = \"\K[^\"]+' pyproject.toml)"
+          for f in plugin.yaml plugins/memory/cashew/plugin.yaml; do
+            sed -i "s/^version: .*/version: ${VERSION}/" "$f"
+            echo "→ $f: version ${VERSION}"
+          done
       - name: Install build dependencies
         run: pip install build
       - name: Build wheel and sdist

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Hermes Agent memory provider plugin backed by Cashew (local SQLite knowledge gra
 
 Thin adapter around upstream [cashew-brain](https://github.com/rajkripal/cashew) — the plugin delegates retrieval, schema management, and LLM operations to upstream. Custom code is limited to Hermes integration surface (config, tools, threading).
 
-## Current State (v0.4.0)
+## Current State (v0.8.2)
 
 - **LLM integration**: `llm_aux_role` config key references `auxiliary.<role>` in Hermes `config.yaml`. Plugin reads Hermes config, resolves credentials, wires `model_fn` callable to upstream. No API keys in plugin config.
 - **Retrieval**: Three-tier (sqlite-vec → BFS → keyword), delegated to upstream `retrieve_recursive_bfs()`.
@@ -38,7 +38,9 @@ git push -u origin HEAD
 
 ### Release Process
 
-Releases are triggered by pushing a `v*` tag. The release workflow gates on tests passing, builds the wheel, and publishes to PyPI via trusted publishing.
+Releases are triggered by pushing a `v*` tag. The release workflow gates on tests passing, auto-syncs plugin manifest versions, builds the wheel, and publishes to PyPI via trusted publishing.
+
+**Important:** You only bump the version in `pyproject.toml` and `CHANGELOG.md` — CI automatically syncs both `plugin.yaml` files to match before building. See [Plugin Version Manifest](#plugin-version-manifest).
 
 ```bash
 # After PR is merged to main:
@@ -58,14 +60,37 @@ The `auxiliary.memory` convention is designed for any Hermes memory provider. Wh
 - `plugins/memory/cashew/__init__.py` — provider implementation (CashewMemoryProvider + register).
 - `plugins/memory/cashew/config.py` — CashewConfig dataclass, DEFAULTS, load/save, schema (31 keys).
 - `plugins/memory/cashew/tools.py` — JSON envelope builders for tool call responses.
-- `plugins/memory/cashew/plugin.yaml` — bundled-loader hook manifest (hooks: [on_session_end]).
-- `plugin.yaml` (root) — `hermes plugins install` manifest, must stay in sync with the above.
+- `plugins/memory/cashew/plugin.yaml` — bundled-loader hook manifest (hooks: [on_session_end, on_pre_compress]). Must match `plugin.yaml` (root).
+- `plugin.yaml` (root) — `hermes plugins install` manifest. CI auto-syncs version from `pyproject.toml` on release.
 - `tests/` — pytest, MemoryManager stub + fake `agent.memory_provider` ABC in `sys.modules`.
 - `.github/workflows/tests.yml` — **do not rename**; filename locked for trusted-publisher config.
 - `.github/workflows/release.yml` — **do not rename**; OIDC bound to filename.
 - `.planning/` — historical GSD workflow artifacts from v0.1/v0.2 development. Schematic reference only; current work is tracked in GitHub issues.
 
 `plugins/` and `plugins/memory/` are PEP 420 namespace packages — do NOT add `__init__.py`.
+
+## Plugin Version Manifest
+
+Hermes-cashew has **three** version-bearing files, and they must all agree:
+
+| File | What it controls | Who bumps it |
+|------|------------------|-------------|
+| `pyproject.toml` | PyPI package version (`pip install`, wheel metadata) | **You** — in the release commit |
+| `plugin.yaml` (root) | Version shown by `hermes plugins install` / `hermes plugin status` | **CI** — auto-synced in the `build` job of `release.yml` |
+| `plugins/memory/cashew/plugin.yaml` | Version in bundled-loader installs (same manifest format) | **CI** — auto-synced (same step as root) |
+
+**The rule:** you only bump `pyproject.toml` when cutting a release. CI reads the version from `pyproject.toml` and patches both `plugin.yaml` files with `sed` before building the wheel and sdist. This happens in the `Sync plugin.yaml versions to pyproject.toml` step of the release workflow, immediately after version-tag validation.
+
+If you ever need to check that all three are in sync locally:
+```bash
+PYPROJ="$(grep -Po '^version = \"\K[^\"]+' pyproject.toml)"
+for f in plugin.yaml plugins/memory/cashew/plugin.yaml; do
+  YAML="$(grep -Po '^version: \K.*' "$f")"
+  if [ "$PYPROJ" != "$YAML" ]; then
+    echo "MISMATCH: $f says $YAML, pyproject.toml says $PYPROJ"
+  fi
+done
+```
 
 ## Key Constraints
 

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -3,7 +3,7 @@
 # Why two plugin.yaml files? Per the Phase 1 install-path spike (same as bundled manifest in plugins/memory/cashew/).
 manifest_version: 1
 name: cashew
-version: 0.1.0
+version: 0.8.2
 description: "Cashew — persistent thought-graph memory with local embeddings, organic decay, and autonomous think cycles."
 pip_dependencies:
   - "cashew-brain"

--- a/plugins/memory/cashew/plugin.yaml
+++ b/plugins/memory/cashew/plugin.yaml
@@ -3,7 +3,7 @@
 # as their methods are implemented. Declaring a hook here whose method doesn't yet exist may trip loader probes.
 manifest_version: 1
 name: cashew
-version: 0.1.0
+version: 0.8.2
 description: "Cashew — persistent thought-graph memory with local embeddings, organic decay, and autonomous think cycles."
 pip_dependencies:
   - "cashew-brain"


### PR DESCRIPTION
## Problem

Both `plugin.yaml` files (root and `plugins/memory/cashew/plugin.yaml`) had `version: 0.1.0` since initial release — never bumped. `hermes plugins install` reads its version from `plugin.yaml`, so users see `0.1.0` in plugin status even though PyPI ships `0.8.2`.

## Changes

**Fix version drift (2 files):**
- `plugin.yaml` — `0.1.0 → 0.8.2`
- `plugins/memory/cashew/plugin.yaml` — `0.1.0 → 0.8.2`

**Prevent recurrence (1 file):**
- `.github/workflows/release.yml` — new `Sync plugin.yaml versions to pyproject.toml` step in `build` job. Reads version from `pyproject.toml` and patches both YAML files before building the wheel/sdist.

**Document the system (1 file):**
- `AGENTS.md` — new `Plugin Version Manifest` section with the three-version taxonomy, updated release process ("you only bump pyproject.toml — CI handles plugin.yaml"), bumped stale Current State header, updated repo layout entries.

## How it works now

```
You bump pyproject.toml → CI validates tag matches → CI syncs plugin.yaml → CI builds
```

No more drift. No manual double-bumps. The commit that fixes pyproject.toml is the only thing you need to remember.