### PR TITLE
chore: bump to v0.9.0, update docs for first-load bootstrap

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.venv
+.git
+__pycache__
+*.pyc
+*.pyo
+.DS_Store
+venv
+node_modules
+.planning
+graphify-out

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,23 @@
 # Changelog
 
-## v0.9.0 (2026-05-14) — Forest-Level Insight Extraction
+## v0.9.0 (2026-05-15) — First-Load Bootstrap & Forest-Level Insight Extraction
 
 ### Added
+
+- **Auto-generate `cashew.json` on first load** — when `initialize()` finds no
+  config file, it writes one with all 32 DEFAULTS so `is_available()` returns
+  `True` immediately after install. Existing configs are never overwritten.
+  ([#47](https://github.com/magnus919/hermes-cashew/issues/47))
+
+- **`llm_aux_role` defaults to `"memory"`** — LLM-powered extraction is active
+  out of the box instead of requiring manual configuration. The plugin
+  auto-populates `auxiliary.memory` in Hermes `config.yaml` from the main
+  model config if absent. ([#47](https://github.com/magnus919/hermes-cashew/issues/47))
+
+- **`is_available()` returns `True` when deps are present** — a fresh install
+  shows green in `hermes memory status` even without a `cashew.json` file,
+  because `initialize()` will generate defaults on first run.
+  ([#47](https://github.com/magnus919/hermes-cashew/issues/47))
 
 - **`on_pre_compress` hook** — Implements the `on_pre_compress(messages)` ABC
   method on `CashewMemoryProvider`. Uses a dedicated LLM extraction prompt

--- a/README.md
+++ b/README.md
@@ -5,7 +5,11 @@ that stores conversation context in a local [Cashew](https://github.com/rajkripa
 thought graph with semantic search and automatic context recall. Get from zero to
 a working install in under five minutes.
 
-**v0.7.0** adds think cycles on a periodic interval. **v0.8.0** re-enables the sleep cycle with a ground-up refactored implementation — vectorized cross-linking, batched DB writes, ~4s at 7K nodes. **v0.9.0** adds conversation-arc insight extraction via `on_pre_compress`.
+**v0.9.0** auto-generates `cashew.json` with defaults on first load, enables
+LLM-powered extraction by default (no manual `auxiliary.memory` setup), and
+adds forest-level insight extraction via `on_pre_compress`. **v0.8.0**
+re-enabled the sleep cycle with a ground-up refactored implementation —
+vectorized cross-linking, batched DB writes, ~4s at 7K nodes.
 
 ## Prerequisites
 
@@ -43,29 +47,22 @@ hermes memory setup
 
 ## Zero-Config Startup
 
-hermes-cashew works out of the box — all 31 configuration keys have sane
-defaults. Create `~/.hermes/cashew.json` only if you want to override them:
+hermes-cashew works out of the box — all 32 configuration keys have sane
+defaults. On first agent startup, the plugin auto-generates `~/.hermes/cashew.json`
+with the full default configuration and auto-populates `auxiliary.memory` in
+Hermes `config.yaml` from the main model config, so LLM-powered extraction
+is active without any manual setup.
+
+Created `~/.hermes/cashew.json` only if you want to override specific defaults.
+The file is never overwritten once it exists:
 
 ```bash
+# Optional: override individual defaults
 cat > ~/.hermes/cashew.json << 'EOF'
 {
-  "cashew_db_path": "cashew/brain.db",
-  "embedding_model": "sentence-transformers/all-MiniLM-L6-v2",
-  "recall_k": 5,
-  "user_domain": "cli/user",
-  "ai_domain": "cli/ai",
-  "sync_queue_timeout": 30,
-  "vec_dimension": 384,
-  "gc_interval_turns": 100,
-  "gc_delete_probability": 0.01,
-  "enable_query_decomposition": true,
-  "max_tokens_per_node": 512,
-  "feature_bfs_retrieval": true,
-  "feature_semantic_search": true,
-  "feature_context_summarization": false,
-  "max_depth": 3,
-  "similarity_threshold": 0.7,
-  "max_nodes_per_query": 20
+  "recall_k": 10,
+  "think_interval": 15,
+  "user_domain": "user"
 }
 EOF
 ```
@@ -135,45 +132,35 @@ keyword fallback. Common use cases:
 - **Domain isolation**: Exclude nodes from specific domains during broad queries
 - **Declassification**: Remove exclusion to reveal previously private nodes
 
-## LLM Integration (Optional)
+## LLM Integration
 
-By default, hermes-cashew uses heuristic-only extraction — it stores
-conversation turns without LLM involvement. To enable LLM-powered features
-(typed nodes, think cycles, sleep synthesis), configure an auxiliary model
-in Hermes' own `config.yaml`:
+hermes-cashew enables LLM-powered extraction by default — `llm_aux_role` is
+set to `"memory"`, and the plugin auto-populates `auxiliary.memory` in Hermes
+`config.yaml` from the main model config on first load.
 
-```yaml
-auxiliary:
-  memory:
-    provider: openrouter          # any Hermes-supported provider
-    model: openai/gpt-4o-mini     # any model available on that provider
+No manual configuration is needed. To verify LLM extraction is active:
+
+```bash
+grep "using" ~/.hermes/logs/agent.log | grep "llm_aux_role"
+# Expected: llm_aux_role='memory': using <provider> <model> via <base_url>
 ```
 
-Then add the role name to `cashew.json`:
+To disable LLM extraction (heuristic-only mode), set `llm_aux_role` to null in
+`cashew.json`:
 
 ```json
-{
-  "cashew_db_path": "cashew/brain.db",
-  "llm_aux_role": "memory"
-}
+{"llm_aux_role": null}
 ```
 
-The plugin reads your Hermes config, resolves the API key from the
-appropriate environment variable, and constructs an OpenAI-compatible
-callable for upstream cashew-brain. No credentials are stored in the
-plugin config.
+Or remove the section entirely — the default will regenerate it on next start.
 
-**What this enables upstream:**
+### What the LLM enables upstream
 
 - **LLM extraction** — structured knowledge extraction with typed nodes,
   confidence scores, tags, and domain assignment
 - **Think cycles** — cross-domain synthesis, generates `insight` nodes
   from clusters of related knowledge. Runs every `think_interval` sync
-  turns (default 10). Configure via `cashew.json`:
-  ```json
-  {"llm_aux_role": "memory", "think_interval": 10}
-  ```
-  Set `think_interval` to 0 to disable.
+  turns (default 10). Set `think_interval` to 0 to disable.
 - **Sleep synthesis** — Runs at session end via `on_session_end()` when
   `sleep_cycles: true`. Nine-phase consolidation pipeline: cross-linking,
   dedup, garbage collection, permanence evaluation, core memory promotion,

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -3,7 +3,7 @@
 # Why two plugin.yaml files? Per the Phase 1 install-path spike (same as bundled manifest in plugins/memory/cashew/).
 manifest_version: 1
 name: cashew
-version: 0.8.2
+version: 0.9.0
 description: "Cashew — persistent thought-graph memory with local embeddings, organic decay, and autonomous think cycles."
 pip_dependencies:
   - "cashew-brain"

--- a/plugins/memory/cashew/plugin.yaml
+++ b/plugins/memory/cashew/plugin.yaml
@@ -3,7 +3,7 @@
 # as their methods are implemented. Declaring a hook here whose method doesn't yet exist may trip loader probes.
 manifest_version: 1
 name: cashew
-version: 0.8.2
+version: 0.9.0
 description: "Cashew — persistent thought-graph memory with local embeddings, organic decay, and autonomous think cycles."
 pip_dependencies:
   - "cashew-brain"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hermes-cashew"
-version = "0.8.2"
+version = "0.9.0"
 description = "Hermes Agent memory provider plugin backed by Cashew thought-graph memory."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## What's in this PR

The code changes for auto-generating defaults and enabling LLM extraction by default were merged prematurely in #48. This PR contains the remaining artifacts that weren't included:

- **Version bump** — pyproject.toml and both plugin.yaml files → v0.9.0
- **CHANGELOG.md** — v0.9.0 entries
- **README.md** — rewritten Zero-Config Startup and LLM Integration sections
- **.dockerignore** — speeds up Docker builds

## Changes

| File | What |
|------|------|
| pyproject.toml | 0.8.2 → 0.9.0 |
| plugin.yaml (root) | 0.8.2 → 0.9.0 |
| plugins/memory/cashew/plugin.yaml | 0.8.2 → 0.9.0 |
| CHANGELOG.md | Added v0.9.0 entries |
| README.md | Rewritten sections |
| .dockerignore | New file |