### PR TITLE
fix(sleep): set PRAGMA busy_timeout=5000 on sleep cycle connection

### DIFF
--- a/plugins/memory/cashew/sleep_refactor.py
+++ b/plugins/memory/cashew/sleep_refactor.py
@@ -617,6 +617,7 @@ def run_sleep_cycle(
     """
     t_start = time.perf_counter()
     conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA busy_timeout=5000")
     _set_wal(conn)
 
     # Select nodes for this cycle (oldest-first heuristic)


### PR DESCRIPTION
## Problem

The sleep cycle's `run_sleep_cycle()` opens a SQLite connection without setting `busy_timeout`. When another Hermes session or background thread holds a write lock, `_batch_cross_links` fails immediately with:

```
sqlite3.OperationalError: database is locked
```

This drops the entire sleep cycle for that session boundary.

## Fix

Add `conn.execute(\"PRAGMA busy_timeout=5000\")` after opening the connection in `run_sleep_cycle()`. SQLite will now wait up to 5 seconds for the lock to release.

## Notes

Related to ongoing SQLite contention work — same pattern as the `_drain_once` retry logic being discussed for the sync worker.