### PR TITLE
fix: load sqlite-vec on connection before vec_embeddings migration

### DIFF
--- a/plugins/memory/cashew/__init__.py
+++ b/plugins/memory/cashew/__init__.py
@@ -513,6 +513,12 @@ class CashewMemoryProvider(MemoryProvider):
         import sqlite3
         conn = sqlite3.connect(str(db_path))
         try:
+            conn.enable_load_extension(True)
+            try:
+                import sqlite_vec
+                sqlite_vec.load(conn)
+            except (ImportError, AttributeError):
+                conn.load_extension("vec0")
             self._migrate_vec_embeddings(conn)
             self._create_vec_embeddings(conn)
             # Hermes provider metadata store (persistent counters, flags)


### PR DESCRIPTION
## Problem

On startup, the agent.log shows:

`plugins.memory.cashew: sqlite-vec not available; skipping vec_embeddings migration`

This is a false negative — sqlite-vec _is_ installed (v0.1.9), but the connection used in `_ensure_db_schema()` never has the extension loaded before `_migrate_vec_embeddings()` queries the `vec_embeddings` virtual table.

## Root cause

In `_ensure_db_schema()`:

1. A raw `sqlite3.connect()` is created — no sqlite-vec loaded
2. `_migrate_vec_embeddings(conn)` is called, which tries `SELECT node_id FROM vec_embeddings LIMIT 1`
3. Without sqlite-vec loaded, the virtual table query throws, the outer except catches it as "not available"
4. `_create_vec_embeddings(conn)` is called _next_ — it does load sqlite-vec correctly, but too late

## Fix

Load sqlite-vec on the connection in `_ensure_db_schema` before calling either method, using the same pattern `_create_vec_embeddings` already uses internally.

## Related

Issue #56