### PR TITLE
refactor(sleep): cross-source linking, edge cap, and out-degree selection

### DIFF
--- a/plugins/memory/cashew/sleep_refactor.py
+++ b/plugins/memory/cashew/sleep_refactor.py
@@ -6,6 +6,16 @@ search, batched DB writes, and a bounded work cap.  Designed to run at
 session end via lifecycle hooks (under 5 seconds for 7K nodes) rather
 than as a standalone cron-scheduled heavyweight.
 
+Features:
+- Cross-source linking: only connects nodes from different source_files,
+  reducing edge noise and improving BFS traversal signal.
+- Edge cap: configurable MAX_EDGES_PER_CYCLE prevents runaway cycles on
+  dense batches (default 100K edges per cycle).
+- Out-degree selection: prioritizes nodes with fewest existing edges,
+  naturally rebalancing the graph over time.
+- Configurable thresholds: CROSS_LINK_THRESHOLD (0.78) controls link density;
+  DEDUP_THRESHOLD (0.82) controls near-duplicate merging.
+
 Usage (from CashewMemoryProvider):
     from .sleep_refactor import run_sleep_cycle
 
@@ -33,9 +43,10 @@ import numpy as np
 logger = logging.getLogger(__name__)
 
 # ── thresholds ──────────────────────────────────────────────────────────────
-CROSS_LINK_THRESHOLD = 0.70   # cosine similarity above which nodes get cross-linked
+CROSS_LINK_THRESHOLD = 0.78   # cosine similarity above which nodes get cross-linked
 DEDUP_THRESHOLD = 0.82        # cosine similarity above which nodes are considered duplicates
 MAX_NODES_PER_CYCLE = 2000    # work cap per cycle
+MAX_EDGES_PER_CYCLE = 100000  # stop cross-linking after this many edges created per cycle
 EDGES_PER_BATCH = 500         # commit after this many edge inserts
 GC_K_NODES = 50               # random sample size for garbage collection
 GC_THRESHOLD = 0.0            # fitness threshold for GC (0 = decay isolated nodes)
@@ -136,17 +147,51 @@ def _batch_cross_links(
     ids: list[str],
     cross_pairs: np.ndarray,
     sim: np.ndarray,
+    source_files: dict[str, str] | None = None,
+    max_edges: int = MAX_EDGES_PER_CYCLE,
 ) -> dict:
-    """Insert cross-link edges in batches. Returns stats dict."""
-    stats = {"candidates": len(cross_pairs), "created": 0, "skipped": 0}
+    """Insert cross-link edges in batches. Returns stats dict.
+
+    Args:
+        conn: SQLite connection.
+        ids: Node IDs corresponding to the similarity matrix rows/cols.
+        cross_pairs: Array of (i, j) index pairs above threshold.
+        sim: Full similarity matrix.
+        source_files: Optional dict mapping node_id → source_file.
+            When provided, pairs sharing the same non-empty source_file are
+            skipped (cross-source linking only).
+        max_edges: Stop after creating this many edges (bidirectional count).
+    """
+    stats = {
+        "candidates": len(cross_pairs),
+        "created": 0,
+        "skipped": 0,
+        "same_source_skipped": 0,
+        "capped": False,
+    }
     pending: list[tuple[str, str, float]] = []
     t0 = time.perf_counter()
 
     for batch_start in range(0, len(cross_pairs), EDGES_PER_BATCH):
+        if stats["created"] >= max_edges:
+            stats["capped"] = True
+            break
         batch = cross_pairs[batch_start:batch_start + EDGES_PER_BATCH]
         for i, j in batch:
+            if stats["created"] >= max_edges:
+                stats["capped"] = True
+                break
             n1 = ids[int(i)]
             n2 = ids[int(j)]
+
+            # Cross-source filter: skip pairs sharing the same source_file
+            if source_files is not None:
+                sf1 = source_files.get(n1, "")
+                sf2 = source_files.get(n2, "")
+                if sf1 and sf2 and sf1 == sf2:
+                    stats["same_source_skipped"] += 1
+                    continue
+
             row = conn.execute(
                 "SELECT COUNT(*) FROM derivation_edges "
                 "WHERE (parent_id=? AND child_id=?) OR (parent_id=? AND child_id=?)",
@@ -173,10 +218,15 @@ def _batch_cross_links(
         pending.clear()
 
     elapsed = time.perf_counter() - t0
-    logger.info(
-        "sleep: cross-links %d created, %d skipped in %.1fs",
-        stats["created"], stats["skipped"], elapsed,
-    )
+    parts = [
+        f"cross-links {stats['created']} created, {stats['skipped']} skipped",
+    ]
+    if stats["same_source_skipped"]:
+        parts.append(f"{stats['same_source_skipped']} same-source skipped")
+    if stats["capped"]:
+        parts.append(f"(capped at {stats['created']})")
+    parts.append(f"in {elapsed:.1f}s")
+    logger.info("sleep: %s", ", ".join(parts))
     return stats
 
 
@@ -619,18 +669,33 @@ def run_sleep_cycle(
     conn = sqlite3.connect(db_path)
     _set_wal(conn)
 
-    # Select nodes for this cycle (oldest-first heuristic)
+    # Select nodes for this cycle (lowest out-degree first, then oldest)
     rows = conn.execute(
         "SELECT e.node_id FROM embeddings e "
         "JOIN thought_nodes tn ON e.node_id = tn.id "
         "WHERE (tn.decayed IS NULL OR tn.decayed = 0) "
-        "ORDER BY tn.timestamp ASC "
+        "ORDER BY "
+        "  (SELECT COUNT(*) FROM derivation_edges WHERE parent_id = tn.id) + "
+        "  (SELECT COUNT(*) FROM derivation_edges WHERE child_id = tn.id) ASC, "
+        "tn.timestamp ASC "
         "LIMIT ?",
         (limit,),
     ).fetchall()
 
     ids = [r[0] for r in rows]
     logger.info("sleep: selected %d nodes (limit=%d)", len(ids), limit)
+
+    # Load source_files for cross-source filtering
+    if not ids:
+        conn.close()
+        return {"error": "no nodes selected"}
+    placeholders = ",".join("?" * len(ids))
+    sf_rows = conn.execute(
+        f"SELECT id, COALESCE(source_file, '') FROM thought_nodes "
+        f"WHERE id IN ({placeholders})",
+        ids,
+    ).fetchall()
+    source_files: dict[str, str] = {row[0]: row[1] for row in sf_rows}
 
     valid_ids, matrix = _load_embedding_matrix(conn, ids)
     if len(valid_ids) < 2:
@@ -642,10 +707,10 @@ def run_sleep_cycle(
     cross_pairs, dedup_pairs, sim = _find_candidates(valid_ids, matrix)
 
     # Phase 2: cross-linking
-    cross_stats = {"created": 0, "skipped": 0}
+    cross_stats = {"created": 0, "skipped": 0, "same_source_skipped": 0, "capped": False}
     cross_link_tuples: list[tuple[str, str, float]] = []
     if len(cross_pairs) > 0:
-        cross_stats = _batch_cross_links(conn, valid_ids, cross_pairs, sim)
+        cross_stats = _batch_cross_links(conn, valid_ids, cross_pairs, sim, source_files=source_files)
         if model_fn is not None:
             for i, j in cross_pairs:
                 cross_link_tuples.append((
@@ -688,6 +753,8 @@ def run_sleep_cycle(
         "dedup_candidates": len(dedup_pairs),
         "cross_links_created": cross_stats["created"],
         "cross_links_skipped": cross_stats["skipped"],
+        "cross_link_same_source_skipped": cross_stats["same_source_skipped"],
+        "cross_link_capped": cross_stats["capped"],
         "dedup_components": dedup_stats["components"],
         "dedup_nodes_merged": dedup_stats["nodes_merged"],
         "nodes_gc_decayed": gc_count,
@@ -701,11 +768,14 @@ def run_sleep_cycle(
     }
 
     logger.info(
-        "sleep: cycle complete in %.1fs — %d nodes, %d cross-links, %d dedups, "
+        "sleep: cycle complete in %.1fs — %d nodes, %d cross-links%s, %d dedups, "
         "%d GC, %d permanent, %d core, %d dream, %d embedded",
         elapsed,
         summary["total_nodes"],
         summary["cross_links_created"],
+        f" ({summary['cross_link_same_source_skipped']} same-source skipped)"
+        if summary["cross_link_same_source_skipped"]
+        else "",
         summary["dedup_nodes_merged"],
         summary["nodes_gc_decayed"],
         summary["nodes_made_permanent"],

--- a/tests/test_sleep_refactor.py
+++ b/tests/test_sleep_refactor.py
@@ -22,6 +22,8 @@ import pytest
 from plugins.memory.cashew.sleep_refactor import (
     CROSS_LINK_THRESHOLD,
     DEDUP_THRESHOLD,
+    MAX_NODES_PER_CYCLE,
+    MAX_EDGES_PER_CYCLE,
     run_sleep_cycle,
     _find_candidates,
     _batch_cross_links,
@@ -233,7 +235,7 @@ def test_batch_cross_links_creates_edges(small_graph):
     edge_after = conn.execute("SELECT COUNT(*) FROM derivation_edges").fetchone()[0]
 
     assert stats["candidates"] >= 0
-    assert stats["created"] + stats["skipped"] == stats["candidates"]
+    assert stats["created"] + stats["skipped"] + stats["same_source_skipped"] == stats["candidates"]
     # Edges may or may not increase depending on pre-existing
     conn.close()
 
@@ -243,7 +245,70 @@ def test_batch_cross_links_empty():
     conn = sqlite3.connect(":memory:")
     _create_schema(conn)
     stats = _batch_cross_links(conn, [], np.array([]).reshape(0, 2), np.array([]))
-    assert stats == {"candidates": 0, "created": 0, "skipped": 0}
+    assert stats == {"candidates": 0, "created": 0, "skipped": 0,
+                     "same_source_skipped": 0, "capped": False}
+    conn.close()
+
+
+def test_batch_cross_links_cross_source_filter(db_path):
+    """Same source_file pairs are skipped when source_files dict is provided."""
+    conn = sqlite3.connect(db_path)
+    # Insert 4 nodes: (a,b) from source_X, (c,d) from source_Y
+    _insert_node(conn, "a", "alpha beta gamma", source_file="source_X")
+    _insert_node(conn, "b", "delta epsilon zeta", source_file="source_X")
+    _insert_node(conn, "c", "eta theta iota", source_file="source_Y")
+    _insert_node(conn, "d", "kappa lambda mu", source_file="source_Y")
+    for nid in ("a", "b", "c", "d"):
+        _insert_embedding(conn, nid, seed={"a": 1, "b": 2, "c": 3, "d": 4}[nid])
+    conn.commit()
+
+    ids = ["a", "b", "c", "d"]
+    from plugins.memory.cashew.sleep_refactor import _load_embedding_matrix
+    valid_ids, matrix = _load_embedding_matrix(conn, ids)
+    cross_pairs, _, sim = _find_candidates(valid_ids, matrix)
+
+    if len(cross_pairs) == 0:
+        conn.close()
+        pytest.skip("No cross-link pairs generated at random with these seeds")
+
+    source_files = {"a": "source_X", "b": "source_X",
+                    "c": "source_Y", "d": "source_Y"}
+
+    stats = _batch_cross_links(conn, valid_ids, cross_pairs, sim,
+                               source_files=source_files)
+
+    assert stats["same_source_skipped"] > 0, \
+        "Expected same-source pairs to be skipped"
+    assert stats["created"] + stats["skipped"] + stats["same_source_skipped"] \
+        == stats["candidates"]
+    conn.close()
+
+
+def test_batch_cross_links_edge_cap(db_path):
+    """max_edges parameter limits the number of edges created."""
+    conn = sqlite3.connect(db_path)
+    # Insert many nodes so we get plenty of cross-link candidates
+    rng = np.random.RandomState(0)
+    for i in range(100):
+        nid = f"n{i:04d}"
+        _insert_node(conn, nid, f"content {i} random {rng.randn():.4f}")
+        _insert_embedding(conn, nid, seed=i)
+    conn.commit()
+
+    ids = [f"n{i:04d}" for i in range(100)]
+    from plugins.memory.cashew.sleep_refactor import _load_embedding_matrix
+    valid_ids, matrix = _load_embedding_matrix(conn, ids)
+    cross_pairs, _, sim = _find_candidates(valid_ids, matrix)
+
+    if len(cross_pairs) == 0:
+        conn.close()
+        pytest.skip("No cross-link pairs generated at random with these seeds")
+
+    # Cap at a tiny number
+    stats = _batch_cross_links(conn, valid_ids, cross_pairs, sim, max_edges=10)
+
+    assert stats["capped"] is True, "Expected cap to be reached"
+    assert stats["created"] == 10, f"Expected 10 edges, got {stats['created']}"
     conn.close()
 
 
@@ -649,6 +714,7 @@ def test_run_sleep_cycle_smoke(small_graph, monkeypatch):
         "nodes_selected", "nodes_with_embeddings",
         "cross_link_candidates", "dedup_candidates",
         "cross_links_created", "cross_links_skipped",
+        "cross_link_same_source_skipped", "cross_link_capped",
         "dedup_components", "dedup_nodes_merged",
         "nodes_gc_decayed", "nodes_made_permanent",
         "core_promoted", "core_demoted",
@@ -666,7 +732,7 @@ def test_run_sleep_cycle_too_few_nodes(empty_graph):
     """Gracefully handles graphs with fewer than 2 embedded nodes."""
     result = run_sleep_cycle(empty_graph, limit=100, model_fn=None)
     assert "error" in result
-    assert result["error"] == "too few nodes"
+    assert result["error"] in ("too few nodes", "no nodes selected")
 
 
 def test_run_sleep_cycle_respects_limit(small_graph):


### PR DESCRIPTION
## Summary

Four changes to the sleep cycle cross-linking phase, addressing the excessive cycle times and diminishing returns documented in #58.

| Change | What | Effect |
|--------|------|--------|
| Raise CROSS_LINK_THRESHOLD | 0.70 to 0.78 | Fewer candidate pairs per batch; sparser graph = better BFS signal |
| MAX_EDGES_PER_CYCLE | New cap at 100K | Caps worst-case cycle to ~30-60s instead of 14+ min |
| Cross-source linking | Skip pairs sharing source_file | Edges only form between different contexts — genuine discovery value |
| Out-degree selection | ORDER BY degree ASC, timestamp ASC | Low-degree nodes processed first; self-stabilizing over time |

## Key design decisions

- source_files dict is passed as optional parameter to _batch_cross_links — zero impact on callers that don't need it (backward compatible).
- Edge cap checks at both batch and per-pair level so it stops cleanly mid-batch.
- Out-degree query uses two indexed subqueries (parent + child) rather than a single OR, so SQLite can use idx_edges_parent and idx_edges_child efficiently.
- New summary fields: cross_link_same_source_skipped and cross_link_capped for observability.

## Testing

- All 33 existing tests pass (3 skipped due to random-seed-dependent candidate generation — same as before)
- New test test_batch_cross_links_cross_source_filter — verifies same-source pairs are skipped
- New test test_batch_cross_links_edge_cap — verifies max_edges stops at the cap
- Existing assertion updated: created + skipped + same_source_skipped == candidates

Closes #58
