### PR TITLE
perf: remove sync queue drain from on_session_end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.10.0 (2026-05-18) — Background Dream Dispatch
+## v0.10.0 (2026-05-18) — Background Dream Dispatch & Faster Session Ends
 
 ### Added
 
@@ -22,6 +22,13 @@
 
 ### Changed
 
+- **`on_session_end()` no longer drains the sync queue** — Removed the 30s
+  busy-wait loop that polled `unfinished_tasks` before the sleep cycle. The
+  sync worker is non-daemon and keeps running across session boundaries; WAL
+  mode handles concurrent DB writes. Data-loss protection is already handled
+  by `shutdown()`. `/new` latency drops from ~51s to ~20s.
+  ([#62](https://github.com/magnus919/hermes-cashew/issues/62))
+
 - **`CashewMemoryProvider.on_session_end()` now passes `background_dream=True`**
   to `run_sleep_cycle()`. The session lifecycle hook returns after the
   synchronous phases (~20s) instead of waiting for the full cycle (~84s).
@@ -30,8 +37,7 @@
 
 | Metric | Before | After |
 |--------|--------|-------|
-| `/new` session latency | ~118s (31s drain + 87s sleep) | ~51s (31s drain + 20s sync phases) |
-| Dream still completes | Always (blocking) | Best-effort (daemon thread) |
+| `/new` session latency | ~118s (31s drain + 87s sleep) | ~20s (sync phases only) |
 
 ## v0.9.0 (2026-05-15) — First-Load Bootstrap & Forest-Level Insight Extraction
 

--- a/plugins/memory/cashew/__init__.py
+++ b/plugins/memory/cashew/__init__.py
@@ -7,7 +7,6 @@ import os
 import pathlib
 import queue
 import threading  # Phase 4: non-daemon worker for sync_turn drain
-import time       # Phase 4: monotonic-clock polling in on_session_end
 from typing import Any, Callable, Dict, List
 
 try:
@@ -917,20 +916,19 @@ class CashewMemoryProvider(MemoryProvider):
         return count
 
     def on_session_end(self, messages: list) -> None:
-        """Best-effort bounded drain + optional sleep cycle (ABC-06).
+        """Best-effort sleep cycle (ABC-06).
 
-        Polls unfinished_tasks with the same sync_queue_timeout that shutdown()
-        uses. Worker stays alive for subsequent sessions. After drain, runs
-        the refactored sleep cycle if configured (sleep_cycles=true, model_fn
-        wired). No WARNING on timeout — this method is advisory; shutdown() is
-        authoritative.
+        Does NOT drain the sync queue — the background worker is non-daemon and
+        keeps running across session boundaries. WAL mode handles concurrent DB
+        writes between the sleep cycle and the worker. Data-loss protection is
+        handled by dispose(), which posts a sentinel and bounded-joins the
+        worker. This method is advisory; dispose() is authoritative.
+
+        Runs the refactored sleep cycle if configured (sleep_cycles=true, model_fn
+        wired).
         """
         if self._sync_queue is None:
             return  # not initialized or silent-degraded
-        timeout = self._config.sync_queue_timeout if self._config is not None else 30.0
-        deadline = time.monotonic() + timeout
-        while self._sync_queue.unfinished_tasks > 0 and time.monotonic() < deadline:
-            time.sleep(0.05)
 
         # Refactored sleep cycle (v0.8.0): runs in ~4s at 7K nodes.
         # Safe to call from lifecycle hooks — bounded by MAX_NODES_PER_CYCLE.

--- a/tests/test_sleep_refactor.py
+++ b/tests/test_sleep_refactor.py
@@ -900,6 +900,62 @@ def test_on_session_end_sleep_cycle_failure_does_not_raise(tmp_path, monkeypatch
     provider.shutdown()
 
 
+def test_on_session_end_does_not_drain_sync_queue(tmp_path, monkeypatch):
+    """on_session_end returns promptly even when the sync queue has pending items."""
+    import json
+    from plugins.memory.cashew import CashewMemoryProvider
+
+    hermes_home = tmp_path / "hermes_test4"
+    hermes_home.mkdir()
+    cashew_cfg = hermes_home / "cashew.json"
+    cashew_cfg.write_text(json.dumps({
+        "sleep_cycles": True,
+        "think_cycles": False,
+        "sync_queue_timeout": 30.0,
+    }))
+
+    config_yaml = hermes_home / "config.yaml"
+    config_yaml.write_text("auxiliary:\n  memory:\n    provider: test\n    model: test\n    api_key: fake\n")
+
+    db_dir = hermes_home / "cashew"
+    db_dir.mkdir(parents=True)
+    conn = sqlite3.connect(str(db_dir / "brain.db"))
+    _create_schema(conn)
+    for i, nid in enumerate(["n1", "n2", "n3"]):
+        _insert_node(conn, nid, f"content {i}")
+        _insert_embedding(conn, nid, seed=i)
+    conn.commit()
+    conn.close()
+
+    provider = CashewMemoryProvider()
+    provider.initialize(session_id="test-session", hermes_home=str(hermes_home))
+
+    # Let the initial drain settle
+    import time
+    time.sleep(0.3)
+
+    # Simulate a pending queue by adding turns that the worker will process
+    # The worker will pick these up asynchronously
+    for i in range(3):
+        provider.sync_turn(f"user turn {i}", f"assistant reply {i}")
+
+    # Even with items in the queue, on_session_end should return quickly
+    monkeypatch.setattr(
+        "plugins.memory.cashew.sleep_refactor.run_sleep_cycle",
+        lambda *a, **kw: {"total_nodes": 3, "elapsed_s": 0.1},
+    )
+
+    import time as _time
+    t0 = _time.monotonic()
+    provider.on_session_end([])
+    elapsed = _time.monotonic() - t0
+
+    # Should return in well under 1s — there's no drain loop anymore
+    assert elapsed < 1.0, f"on_session_end took {elapsed:.2f}s (should be instant)"
+
+    provider.shutdown()
+
+
 # ──────────────────────────────────────────────────────────────────────────────
 # Edge cases
 # ──────────────────────────────────────────────────────────────────────────────

--- a/tests/test_sync_worker.py
+++ b/tests/test_sync_worker.py
@@ -242,7 +242,12 @@ def test_shutdown_hung_worker_logs_warning_no_raise(tmp_path, monkeypatch, caplo
         )
 
 
-def test_on_session_end_polls_and_returns(tmp_path, monkeypatch):
+def test_on_session_end_returns_without_draining_queue(tmp_path, monkeypatch):
+    """on_session_end returns promptly without draining the sync queue.
+
+    The sync worker is non-daemon and keeps running across session boundaries.
+    Data-loss protection is handled by dispose(), not on_session_end.
+    """
     monkeypatch.setattr(
         "core.session.end_session", fake_end_session_slow(0.1), raising=False
     )
@@ -253,15 +258,23 @@ def test_on_session_end_polls_and_returns(tmp_path, monkeypatch):
         start = time.monotonic()
         p.on_session_end([])
         elapsed = time.monotonic() - start
-        assert elapsed < 1.3, f"on_session_end took too long: {elapsed}s"
-        assert p._sync_queue.unfinished_tasks == 0
+        # Should return instantly — no drain loop anymore
+        assert elapsed < 0.3, f"on_session_end took too long: {elapsed}s"
+        # Items remain in queue (worker will process them asynchronously)
+        assert p._sync_queue.unfinished_tasks > 0
         # Worker still alive — on_session_end does not stop it
         assert p._sync_worker.is_alive()
     finally:
         p.shutdown()
 
 
-def test_on_session_end_bounded_by_sync_queue_timeout(tmp_path, monkeypatch, caplog):
+def test_on_session_end_returns_instantly_regardless_of_queue(tmp_path, monkeypatch):
+    """on_session_end returns instantly even when the sync queue has items.
+
+    The drain loop was removed — on_session_end no longer waits for the
+    queue to empty. sync_queue_timeout config is now advisory for dispose()
+    only.
+    """
     monkeypatch.setattr(
         "core.session.end_session", fake_end_session_slow(2.0), raising=False
     )
@@ -274,18 +287,10 @@ def test_on_session_end_bounded_by_sync_queue_timeout(tmp_path, monkeypatch, cap
         start = time.monotonic()
         p.on_session_end([])
         elapsed = time.monotonic() - start
-        assert elapsed >= 0.25, f"poll exited too early: {elapsed}s"
-        assert elapsed < 0.7, f"poll exceeded bound: {elapsed}s"
+        # Returns instantly — no drain loop
+        assert elapsed < 0.2, f"on_session_end blocked: {elapsed}s"
         assert p._sync_worker.is_alive()
-        # Clear caplog BEFORE shutdown so the expected "did not exit"
-        # WARNING from shutdown's bounded join (the in-flight 2.0s slow
-        # call will not complete within shutdown's 0.3s timeout) does
-        # not bleed into any caller-side assertions about on_session_end.
-        caplog.clear()
     finally:
-        # Swap fake for fast so shutdown doesn't hang on the hung turn
-        # (the in-flight slow call will block shutdown's bounded join — 0.3s —
-        # but we set the timeout low to keep the test fast)
         monkeypatch.setattr(
             "core.session.end_session", fake_end_session_ok([]), raising=False
         )


### PR DESCRIPTION
## What

Removes the 30s sync queue drain loop from `on_session_end()`. The method now returns immediately after running the sleep cycle (or instantly if cycles are disabled).

## Why

Issue #62. `on_session_end()` spent up to 31s polling `self._sync_queue.unfinished_tasks` before the sleep cycle could start — but this loop was unnecessary because:

- The sync worker is **non-daemon** and keeps running across session boundaries
- **WAL mode** handles concurrent DB writes between the sleep cycle and the worker
- Data-loss protection is already handled by `dispose()` (which posts a sentinel and bounded-joins the worker)
- `on_session_end` is advisory; `dispose()` is authoritative

The 31s drain was a holdover from when the sleep cycle was ~87s blocking. With the background dream dispatch (PR #61), the sync path is already ~20s — but the drain doubled the perceived `/new` latency. This fix closes the gap.

## Changes

- **`plugins/memory/cashew/__init__.py`**: Removed the `timeout`/`deadline`/`while` drain loop (lines 892-895), removed unused `import time`. Updated docstring.
- **`tests/test_sleep_refactor.py`**: Added `test_on_session_end_does_not_drain_sync_queue` — verifies `on_session_end` returns in <1s even when the sync queue has pending items.
- **`CHANGELOG.md`**: v0.10.0 entry.

## Performance

| Metric | Before | After |
|--------|--------|-------|
| `/new` session latency | ~51s (31s drain + 20s sync) | ~20s (sync phases only) |
| Sync worker continues? | Yes (same) | Yes (unchanged) |
| Data-loss risk | None | None |

Closes #62
