### PR TITLE
feat(sleep): raise default CROSS_LINK_THRESHOLD to 0.78

### DIFF
--- a/plugins/memory/cashew/sleep_refactor.py
+++ b/plugins/memory/cashew/sleep_refactor.py
@@ -41,7 +41,7 @@ import numpy as np
 logger = logging.getLogger(__name__)
 
 # ── thresholds ──────────────────────────────────────────────────────────────
-CROSS_LINK_THRESHOLD = 0.70   # cosine similarity above which nodes get cross-linked
+CROSS_LINK_THRESHOLD = 0.78   # cosine similarity above which nodes get cross-linked
 DEDUP_THRESHOLD = 0.82        # cosine similarity above which nodes are considered duplicates
 MAX_NODES_PER_CYCLE = 2000    # work cap per cycle
 MAX_EDGES_PER_CYCLE = 100_000 # edge cap per cycle


### PR DESCRIPTION
Closes #66

Raises the default cross-link threshold from 0.70 to 0.78 based on production experience. See issue #66 for full motivation and trade-offs.