### PR TITLE
fix: add GC grace period and decayed-node filter for keyword search

### DIFF
--- a/plugins/memory/cashew/__init__.py
+++ b/plugins/memory/cashew/__init__.py
@@ -1190,7 +1190,7 @@ class CashewMemoryProvider(MemoryProvider):
         import sqlite3
         conn = sqlite3.connect(str(self._db_path))
         try:
-            where_clauses: list[str] = []
+            where_clauses: list[str] = ["(decayed IS NULL OR decayed = 0)"]
             params: list = []
             words = [w for w in query.split() if w]
             if words:

--- a/plugins/memory/cashew/sleep_refactor.py
+++ b/plugins/memory/cashew/sleep_refactor.py
@@ -48,6 +48,7 @@ MAX_EDGES_PER_CYCLE = 100_000 # edge cap per cycle
 EDGES_PER_BATCH = 500         # commit after this many edge inserts
 GC_K_NODES = 50               # random sample size for garbage collection
 GC_THRESHOLD = 0.0            # fitness threshold for GC (0 = decay isolated nodes)
+GC_GRACE_DAYS = 7             # min node age (days) before GC can decay it
 
 
 # ── helpers ─────────────────────────────────────────────────────────────────
@@ -386,6 +387,21 @@ def _garbage_collect(
         nid for nid, m in metrics.items()
         if nid not in perm_ids and m["fitness"] <= GC_THRESHOLD
     ]
+
+    # Age gate: exclude nodes created within the grace period
+    if candidates and GC_GRACE_DAYS > 0:
+        import datetime
+        cutoff = (
+            datetime.datetime.utcnow() - datetime.timedelta(days=GC_GRACE_DAYS)
+        ).isoformat()
+        ph = ",".join("?" * len(candidates))
+        young = {
+            r[0] for r in conn.execute(
+                f"SELECT id FROM thought_nodes WHERE id IN ({ph}) AND timestamp >= ?",
+                [*candidates, cutoff],
+            ).fetchall()
+        }
+        candidates = [nid for nid in candidates if nid not in young]
 
     sample = (
         candidates


### PR DESCRIPTION
## Summary

- Add `GC_GRACE_DAYS = 7` to sleep cycle — prevents garbage collection from decaying nodes younger than one week, fixing the "memory loss" bug where isolated nodes could be decayed within minutes of creation
- Filter decayed nodes out of `_keyword_search()` fallback results — closes a hole where decayed content could leak through the keyword recall path

## Related Issues

Closes #68

## Test Plan

- [ ] Unit tests pass (`pytest`)
- [ ] New tests added for the change
- [x] Manual verification — logic reviewed against the GC path and keyword search SQL

The GC age gate adds one batched timestamp query to the candidates list before sampling. When `GC_GRACE_DAYS = 0` (or negative), the age gate is skipped entirely — no query overhead. The keyword fix is a one-line WHERE clause addition.

## Breaking Changes

None. The GC age gate is additive (only reduces which nodes can be decayed). The keyword decayed filter is also additive (only removes results that should already have been excluded).

## Notes for Reviewers

Bug #3 from the issue (confidence threshold) was not addressed — the upstream cashew-brain uses a binary `keep` gate, not a confidence score, so the claim was based on hallucinated code. The two real bugs are fixed here.
