### PR TITLE
chore: bump to v0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## v0.10.1 (2026-05-22) — GC Grace Period, Keyword Decay Filter & Threshold Tuning
+
+### Added
+
+- **GC grace period (`GC_GRACE_DAYS = 7`)** — Garbage collection now skips
+  nodes created within the last 7 days, preventing recently-created isolated
+  nodes from being immediately decayed. Fixes systematic memory loss for
+  single-reference knowledge.
+  ([#68](https://github.com/magnus919/hermes-cashew/issues/68) —
+  report by [@boriken72](https://github.com/boriken72))
+  ([#69](https://github.com/magnus919/hermes-cashew/pull/69))
+
+- **Decayed-node filter in `_keyword_search()`** — The keyword fallback
+  retrieval path now excludes decayed nodes, closing a hole where decayed
+  content could leak through.
+  ([#68](https://github.com/magnus919/hermes-cashew/issues/68) —
+  report by [@boriken72](https://github.com/boriken72))
+  ([#69](https://github.com/magnus919/hermes-cashew/pull/69))
+
+### Changed
+
+- **Default `CROSS_LINK_THRESHOLD` raised from 0.70 → 0.78** — Reduces
+  low-value cross-link candidates in the sleep cycle, steering edges toward
+  genuinely similar content clusters.
+  ([#67](https://github.com/magnus919/hermes-cashew/pull/67))
+
+### Acknowledgements
+
+Thanks to [@boriken72](https://github.com/boriken72) for the detailed
+investigation in issue #68 that identified the GC grace-period gap and the
+keyword-search decay filter miss.
+
 ## v0.10.0 (2026-05-17) — Cross-Source Linking, Queue Prefetch, Background Dream Dispatch & Faster Session Ends
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hermes-cashew"
-version = "0.10.0"
+version = "0.10.1"
 description = "Hermes Agent memory provider plugin backed by Cashew thought-graph memory."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary

- Bump version from v0.10.0 → v0.10.1
- Add CHANGELOG entry for GC grace period, keyword decay filter, and threshold tuning
- Tag v0.10.1 already pushed

## Related Issues

Closes #68

## Test Plan

- [ ] Unit tests pass (`pytest`)
- [ ] New tests added for the change
- [ ] Manual verification — CHANGELOG reviewed against git log v0.10.0..HEAD

## Breaking Changes

None

## Notes for Reviewers

Minor patch version bump only. No code changes in this commit — the code changes (PR #69, PR #67) are already on main. This PR just versions and documents them.
