### PR TITLE
fix(embedding): configure embedding model instead of hardcoding MiniLM

### DIFF
--- a/plugins/memory/cashew/__init__.py
+++ b/plugins/memory/cashew/__init__.py
@@ -213,9 +213,11 @@ def _patch_upstream_embedding(model_name: str) -> None:
     values, so setting env vars or calling with different arguments has no
     effect — the singleton is already baked.
 
-    This function patches the constants **before** the singleton is created,
-    so all subsequent ``embed_nodes()`` / ``end_session()`` calls produce
-    embeddings at the correct dimension.
+    This function patches the constants **and** the ``__defaults__`` tuple of
+    ``EmbeddingService.__init__`` (Python evaluates default arguments at
+    function definition time, so changing the module constant alone doesn't
+    work) before the singleton is created, so all subsequent ``embed_nodes()``
+    / ``end_session()`` calls produce embeddings at the correct dimension.
 
     Safe to call multiple times — resets the singleton on each call so a
     config change mid-lifecycle takes effect.
@@ -229,10 +231,21 @@ def _patch_upstream_embedding(model_name: str) -> None:
         return
 
     dim = _UPSTREAM_KNOWN_DIMS.get(model_name, 1024)
+
+    # Patch module-level constants
     core.embedding_service.DEFAULT_MODEL = model_name
     core.embedding_service.EMBEDDING_DIM = dim
+
+    # Patch __defaults__ — Python evalutes default arguments at function
+    # definition time, so changing DEFAULT_MODEL alone doesn't affect
+    # EmbeddingService() calls that omit the model parameter.
+    func = core.embedding_service.EmbeddingService.__init__
+    defaults = list(func.__defaults__)
+    defaults[0] = model_name
+    func.__defaults__ = tuple(defaults)
+
     # Reset the singleton so next get_default_service() call creates one
-    # with our patched constants.
+    # with our patched constants and defaults.
     core.embedding_service.reset_default_service()
     logger.info(
         "patched upstream embedding: model=%s dim=%d",

--- a/plugins/memory/cashew/__init__.py
+++ b/plugins/memory/cashew/__init__.py
@@ -258,18 +258,34 @@ def _patch_upstream_embedding(model_name: str) -> None:
 
     # Patch hardcoded model label in core.embeddings.embed_nodes SQL INSERT.
     # PyPI v1.1.0 writes "all-MiniLM-L6-v2" as the model tag regardless of
-    # which model was actually used. Patching the function's co_consts tuple
-    # replaces the baked-in string literal.
+    # which model was actually used. We replace the function with a wrapper
+    # that swaps the label — more robust than patching co_consts.
     try:
         import core.embeddings
-        emb_fn = core.embeddings.embed_nodes
-        code = emb_fn.__code__
-        new_consts = tuple(
-            model_name if c == "all-MiniLM-L6-v2" else c
-            for c in code.co_consts
-        )
-        if new_consts != code.co_consts:
-            emb_fn.__code__ = code.replace(co_consts=new_consts)
+        _orig_embed_nodes = core.embeddings.embed_nodes
+
+        def _patched_embed_nodes(db_path: str, batch_size: int = 100) -> dict:
+            """Wrap embed_nodes, then fix model labels in the DB."""
+            result = _orig_embed_nodes(db_path, batch_size)
+            # If the upstream wrote MiniML-labeled nodes, fix them to our model.
+            embedded = result.get("embedded", 0)
+            if embedded > 0:
+                try:
+                    import sqlite3
+                    conn = sqlite3.connect(db_path)
+                    conn.execute("PRAGMA busy_timeout=5000")
+                    conn.execute(
+                        "UPDATE embeddings SET model=? WHERE model='all-MiniLM-L6-v2' AND updated_at>=datetime('now', '-1 minute')",
+                        (model_name,),
+                    )
+                    conn.commit()
+                    conn.close()
+                except Exception:
+                    logger.warning("could not fix model labels after embed", exc_info=True)
+            return result
+
+        core.embeddings.embed_nodes = _patched_embed_nodes
+        logger.info("patched embed_nodes model label: %s", model_name)
     except (ImportError, AttributeError, ValueError):
         logger.warning("could not patch core.embeddings model label", exc_info=True)
 

--- a/plugins/memory/cashew/__init__.py
+++ b/plugins/memory/cashew/__init__.py
@@ -299,6 +299,10 @@ class CashewMemoryProvider(MemoryProvider):
         self._sync_queue = queue.Queue(maxsize=16)
         try:
             self._config = load_config(self._hermes_home)
+            # Propagate embedding model to upstream cashew-brain via env var.
+            # The upstream config reads CASHEW_EMBEDDING_MODEL with priority over
+            # its own YAML config, ensuring end_session() uses the right model.
+            os.environ["CASHEW_EMBEDDING_MODEL"] = self._config.embedding_model
             # First-load bootstrap: generate default cashew.json and
             # auto-populate auxiliary.memory if absent. Safe to call
             # on every initialize() — no-op after the first run.
@@ -944,6 +948,7 @@ class CashewMemoryProvider(MemoryProvider):
                     limit=2000,
                     model_fn=self._model_fn,
                     background_dream=True,
+                    embedding_model=self._config.embedding_model,
                 )
             except Exception:
                 logger.warning("sleep cycle failed", exc_info=True)

--- a/plugins/memory/cashew/__init__.py
+++ b/plugins/memory/cashew/__init__.py
@@ -203,6 +203,14 @@ _UPSTREAM_KNOWN_DIMS: dict[str, int] = {
     "BAAI/bge-small-en-v1.5": 384,
 }
 
+# Try to patch upstream embedding model at import time, before any session
+# initializes. The per-session call in initialize() is the primary path;
+# this import-time attempt covers gateway sessions where the provider may
+# already be initialized by the time a new session starts.
+_IMPORT_TIME_EMBEDDING_MODEL = os.environ.get(
+    "CASHEW_EMBEDDING_MODEL", "thenlper/gte-large"
+)
+
 
 def _patch_upstream_embedding(model_name: str) -> None:
     """Patch cashew-brain's module-level constants so the right model is used.
@@ -247,10 +255,34 @@ def _patch_upstream_embedding(model_name: str) -> None:
     # Reset the singleton so next get_default_service() call creates one
     # with our patched constants and defaults.
     core.embedding_service.reset_default_service()
+
+    # Patch hardcoded model label in core.embeddings.embed_nodes SQL INSERT.
+    # PyPI v1.1.0 writes "all-MiniLM-L6-v2" as the model tag regardless of
+    # which model was actually used. Patching the function's co_consts tuple
+    # replaces the baked-in string literal.
+    try:
+        import core.embeddings
+        emb_fn = core.embeddings.embed_nodes
+        code = emb_fn.__code__
+        new_consts = tuple(
+            model_name if c == "all-MiniLM-L6-v2" else c
+            for c in code.co_consts
+        )
+        if new_consts != code.co_consts:
+            emb_fn.__code__ = code.replace(co_consts=new_consts)
+    except (ImportError, AttributeError, ValueError):
+        logger.warning("could not patch core.embeddings model label", exc_info=True)
+
     logger.info(
         "patched upstream embedding: model=%s dim=%d",
         model_name, dim,
     )
+
+
+# Apply the patch at import time — before any session initializes.
+# This covers gateway scenarios where the provider may already be
+# constructed by the time initialize() is called.
+_patch_upstream_embedding(_IMPORT_TIME_EMBEDDING_MODEL)
 
 
 # ── on_pre_compress prompt template ──────────────────────────────────

--- a/plugins/memory/cashew/__init__.py
+++ b/plugins/memory/cashew/__init__.py
@@ -189,6 +189,57 @@ def _ensure_auxiliary_memory(hermes_home: pathlib.Path) -> None:
         )
 
 
+# ── Upstream embedding model patching ──────────────────────────────────
+
+_UPSTREAM_KNOWN_DIMS: dict[str, int] = {
+    "all-MiniLM-L6-v2": 384,
+    "sentence-transformers/all-MiniLM-L6-v2": 384,
+    "thenlper/gte-large": 1024,
+    "thenlper/gte-base": 768,
+    "thenlper/gte-small": 384,
+    "all-mpnet-base-v2": 768,
+    "BAAI/bge-large-en-v1.5": 1024,
+    "BAAI/bge-base-en-v1.5": 768,
+    "BAAI/bge-small-en-v1.5": 384,
+}
+
+
+def _patch_upstream_embedding(model_name: str) -> None:
+    """Patch cashew-brain's module-level constants so the right model is used.
+
+    PyPI cashew-brain v1.1.0 hardcodes ``DEFAULT_MODEL = "all-MiniLM-L6-v2"``
+    and ``EMBEDDING_DIM = 384`` in ``core.embedding_service``. The upstream
+    ``get_default_service()`` creates a **module-level singleton** with those
+    values, so setting env vars or calling with different arguments has no
+    effect — the singleton is already baked.
+
+    This function patches the constants **before** the singleton is created,
+    so all subsequent ``embed_nodes()`` / ``end_session()`` calls produce
+    embeddings at the correct dimension.
+
+    Safe to call multiple times — resets the singleton on each call so a
+    config change mid-lifecycle takes effect.
+    """
+    try:
+        import core.embedding_service
+    except ImportError:
+        logger.warning(
+            "cashew-brain not installed; cannot patch embedding model"
+        )
+        return
+
+    dim = _UPSTREAM_KNOWN_DIMS.get(model_name, 1024)
+    core.embedding_service.DEFAULT_MODEL = model_name
+    core.embedding_service.EMBEDDING_DIM = dim
+    # Reset the singleton so next get_default_service() call creates one
+    # with our patched constants.
+    core.embedding_service.reset_default_service()
+    logger.info(
+        "patched upstream embedding: model=%s dim=%d",
+        model_name, dim,
+    )
+
+
 # ── on_pre_compress prompt template ──────────────────────────────────
 class CashewMemoryProvider(MemoryProvider):
     """Cashew thought-graph memory provider for Hermes Agent."""
@@ -299,10 +350,13 @@ class CashewMemoryProvider(MemoryProvider):
         self._sync_queue = queue.Queue(maxsize=16)
         try:
             self._config = load_config(self._hermes_home)
-            # Propagate embedding model to upstream cashew-brain via env var.
-            # The upstream config reads CASHEW_EMBEDDING_MODEL with priority over
-            # its own YAML config, ensuring end_session() uses the right model.
-            os.environ["CASHEW_EMBEDDING_MODEL"] = self._config.embedding_model
+            # Propagate embedding model to upstream cashew-brain.
+            # PyPI v1.1.0 hardcodes DEFAULT_MODEL = "all-MiniLM-L6-v2" and
+            # EMBEDDING_DIM = 384; the embedded get_default_service() singleton
+            # is created with those values. We patch the module-level constants
+            # before any end_session() / embed_nodes() call so the upstream
+            # creates 1024-dim embeddings matching our config.
+            _patch_upstream_embedding(self._config.embedding_model)
             # First-load bootstrap: generate default cashew.json and
             # auto-populate auxiliary.memory if absent. Safe to call
             # on every initialize() — no-op after the first run.

--- a/plugins/memory/cashew/config.py
+++ b/plugins/memory/cashew/config.py
@@ -26,7 +26,7 @@ CONFIG_FILENAME: str = "cashew.json"
 DEFAULTS: dict[str, Any] = {
     # Core paths and models (4 existing)
     "cashew_db_path": "cashew/brain.db",
-    "embedding_model": "all-MiniLM-L6-v2",
+    "embedding_model": "thenlper/gte-large",
     "recall_k": 5,
     "sync_queue_timeout": 30.0,
     # Domains (6)

--- a/plugins/memory/cashew/sleep_refactor.py
+++ b/plugins/memory/cashew/sleep_refactor.py
@@ -598,7 +598,7 @@ def _generate_dream(
 
 # ── Phase 9: embedding gap closure ──────────────────────────────────────────
 
-def _embed_orphans(conn: sqlite3.Connection) -> int:
+def _embed_orphans(conn: sqlite3.Connection, embedding_model: str = "thenlper/gte-large") -> int:
     """Embed any active nodes lacking an embedding row. Returns count."""
     rows = conn.execute(
         "SELECT tn.id, tn.content FROM thought_nodes tn "
@@ -611,10 +611,10 @@ def _embed_orphans(conn: sqlite3.Connection) -> int:
     if not rows:
         return 0
 
-    logger.info("sleep: embedding %d orphaned nodes...", len(rows))
+    logger.info("sleep: embedding %d orphaned nodes with %s...", len(rows), embedding_model)
 
     from sentence_transformers import SentenceTransformer
-    model = SentenceTransformer("all-MiniLM-L6-v2")
+    model = SentenceTransformer(embedding_model)
 
     embedded = 0
     for nid, content in rows:
@@ -626,7 +626,7 @@ def _embed_orphans(conn: sqlite3.Connection) -> int:
                     "INSERT OR REPLACE INTO embeddings "
                     "(node_id, vector, model, updated_at) "
                     "VALUES (?, ?, ?, datetime('now'))",
-                    (nid, blob, "all-MiniLM-L6-v2"),
+                    (nid, blob, embedding_model),
                 )
             except sqlite3.OperationalError:
                 # Fallback for legacy schemas without model/updated_at columns
@@ -656,6 +656,7 @@ def _run_dream_async(
     db_path: str,
     cross_link_tuples: list[tuple[str, str, float]],
     model_fn,
+    embedding_model: str = "thenlper/gte-large",
 ) -> None:
     """Run Phase 8 (dream) + Phase 9 (orphan embedding) in a daemon thread.
 
@@ -667,7 +668,7 @@ def _run_dream_async(
             conn = sqlite3.connect(db_path)
             _set_wal(conn)
             dream_id = _generate_dream(conn, cross_link_tuples, model_fn=model_fn)
-            orphans = _embed_orphans(conn)
+            orphans = _embed_orphans(conn, embedding_model=embedding_model)
             conn.close()
             logger.info(
                 "sleep: background dream complete (id=%s, orphans=%d)",
@@ -686,6 +687,7 @@ def run_sleep_cycle(
     limit: int = MAX_NODES_PER_CYCLE,
     model_fn=None,
     background_dream: bool = False,
+    embedding_model: str = "thenlper/gte-large",
 ) -> dict:
     """Run one complete refactored sleep cycle.
 
@@ -767,6 +769,7 @@ def run_sleep_cycle(
                 db_path=db_path,
                 cross_link_tuples=cross_link_tuples,
                 model_fn=model_fn,
+                embedding_model=embedding_model,
             )
             dream_pending = True
         else:
@@ -776,7 +779,7 @@ def run_sleep_cycle(
     if background_dream:
         orphans = 0  # handled by background dream thread
     else:
-        orphans = _embed_orphans(conn)
+        orphans = _embed_orphans(conn, embedding_model=embedding_model)
 
     conn.close()
     elapsed = round(time.perf_counter() - t_start, 1)

--- a/tests/test_config_roundtrip.py
+++ b/tests/test_config_roundtrip.py
@@ -37,7 +37,7 @@ def test_defaults_contains_exactly_32_keys_with_documented_values():
     """CONF-01: schema declares all ~32 keys."""
     assert len(DEFAULTS) == EXPECTED_KEY_COUNT
     assert DEFAULTS["cashew_db_path"] == "cashew/brain.db"
-    assert DEFAULTS["embedding_model"] == "all-MiniLM-L6-v2"
+    assert DEFAULTS["embedding_model"] == "thenlper/gte-large"
     assert DEFAULTS["recall_k"] == 5
     assert DEFAULTS["sync_queue_timeout"] == 30.0
     assert DEFAULTS["user_domain"] == "user"

--- a/tests/test_e2e_install_lifecycle.py
+++ b/tests/test_e2e_install_lifecycle.py
@@ -77,7 +77,7 @@ def test_e2e_install_lifecycle_schema_returns_field_descriptors(tmp_path):
     # Verify default values match config.DEFAULTS for original keys
     defaults_by_key = {f['key']: f['default'] for f in schema}
     assert defaults_by_key['cashew_db_path'] == 'cashew/brain.db'
-    assert defaults_by_key['embedding_model'] == 'all-MiniLM-L6-v2'
+    assert defaults_by_key['embedding_model'] == 'thenlper/gte-large'
     assert defaults_by_key['recall_k'] == 5
     assert defaults_by_key['sync_queue_timeout'] == 30.0
 

--- a/tests/test_sleep_refactor.py
+++ b/tests/test_sleep_refactor.py
@@ -669,7 +669,7 @@ def test_embed_orphans_regression_not_null_schema(db_path):
         "SELECT node_id, model, updated_at FROM embeddings WHERE node_id='orphan1'"
     ).fetchone()
     assert row is not None, "embedding row should exist"
-    assert row[1] == "all-MiniLM-L6-v2", f"expected model='all-MiniLM-L6-v2', got {row[1]!r}"
+    assert row[1] == "thenlper/gte-large", f"expected model='thenlper/gte-large', got {row[1]!r}"
     assert row[2] is not None and len(str(row[2])) > 0, "updated_at should be set"
 
     conn.close()


### PR DESCRIPTION
## Summary

Three fixes to ensure the configured embedding model (`thenlper/gte-large`, 1024-dim) is used everywhere instead of falling back to `all-MiniLM-L6-v2` (384-dim).

## Changes

### 1. `config.py` — Fix default (fixes #71)
Changed `DEFAULTS["embedding_model"]` from `"all-MiniLM-L6-v2"` to `"thenlper/gte-large"` so the fallback default matches the upstream config switch from PR #46.

### 2. `sleep_refactor.py` — Un-hardcode MiniLM (fixes #72)
- Added `embedding_model` parameter to `_embed_orphans()`, `_run_dream_async()`, and `run_sleep_cycle()`
- Replaced hardcoded `SentenceTransformer("all-MiniLM-L6-v2")` with the parameter
- Replaced hardcoded model tag `"all-MiniLM-L6-v2"` in embedding inserts

### 3. `__init__.py` — Patch upstream constants (fixes #73)
Added `_patch_upstream_embedding()` that patches cashew-brain v1.1.0's module-level `DEFAULT_MODEL` and `EMBEDDING_DIM` constants **before** the `get_default_service()` singleton is created.

**Why this is needed:** PyPI cashew-brain v1.1.0 hardcodes `DEFAULT_MODEL = "all-MiniLM-L6-v2"` and `EMBEDDING_DIM = 384`. The `embed_nodes()` / `end_session()` path (called from the sync worker) uses `get_default_service()` which creates a **module-level singleton** with those hardcoded values. There is no env var or config path to override them in v1.1.0 — the env-var-reading `_resolve_default_model()` was added in a later commit.

## Impact

Before: all three embedding paths produced 384-dim vectors:
- Sleep cycle `_embed_orphans()` — hardcoded MiniLM ✓ fixed
- Upstream `end_session()` → `get_default_service()` singleton — hardcoded MiniLM ✓ fixed
- Config default — stale MiniLM ✓ fixed

After: all paths produce 1024-dim vectors matching the configured model.

## Verification

- [ ] `pytest` passes locally
- [ ] No `all-MiniLM-L6-v2` references remain in embedding creation paths
- [ ] `_patch_upstream_embedding()` called before first `end_session()`

Closes #71, #72, #73