### PR TITLE
fix(plugin): resolve vec_embeddings dimension dynamically

### DIFF
--- a/plugins/memory/cashew/__init__.py
+++ b/plugins/memory/cashew/__init__.py
@@ -842,11 +842,20 @@ class CashewMemoryProvider(MemoryProvider):
                 sqlite_vec.load(conn)
             except (ImportError, AttributeError):
                 conn.load_extension("vec0")
-            conn.execute("""
+            # Resolve the configured embedding model's dimension at runtime
+            # instead of hardcoding float[384] — supports gte-large (1024),
+            # gte-base (768), MiniLM (384), etc. Without this, vec_embeddings
+            # silently refuses dual-writes from any model with a different dim.
+            try:
+                from core.embedding_service import resolve_embedding_dim
+                dim = resolve_embedding_dim()
+            except Exception:
+                dim = 384  # fallback for test environments without models
+            conn.execute(f"""
                 CREATE VIRTUAL TABLE IF NOT EXISTS vec_embeddings
-                USING vec0(node_id TEXT primary key, embedding float[384] distance_metric=cosine)
+                USING vec0(node_id TEXT primary key, embedding float[{dim}] distance_metric=cosine)
             """)
-            logger.debug("vec_embeddings virtual table ready")
+            logger.debug(f"vec_embeddings virtual table ready (dim={dim})")
         except Exception:
             logger.info("sqlite-vec not available; semantic search will use fallback")
 


### PR DESCRIPTION
Fixes #78

## Problem

`_create_vec_embeddings()` hardcodes `float[384]` in the sqlite-vec DDL. When the configured embedding model produces a different dimension (e.g. `thenlper/gte-large` at 1024-dim), the mismatch causes `embed_nodes()` to silently skip the vec_embeddings dual-write — all new embeddings go to the `embeddings` table only, never to the vector index.

The upstream `_ensure_embeddings_table()` in cashew-brain already handles this dynamically via `_current_embedding_dim()`. The plugin was simply never updated to match.

## Impact

On affected systems, vec_embeddings becomes a stale 384-dim index. Vector search via sqlite-vec only searches the old subset. All correctly-dimensioned embeddings are reachable only via brute-force O(N) scan.

## Fix

Replace the hardcoded `float[384]` with a dynamic dimension resolved from the configured embedding model, falling back to 384 for test environments where models aren't available.

## Post-fix steps for existing databases

1. Drop the old vec_embeddings table (recreated at correct dim on next plugin init)
2. Run backfill_vec_index() to dual-write existing embeddings into the new index
