### PR TITLE
fix(sleep): add busy_timeout to SQLite connections in sleep cycle

### DIFF
--- a/plugins/memory/cashew/sleep_refactor.py
+++ b/plugins/memory/cashew/sleep_refactor.py
@@ -27,6 +27,7 @@
 
 from __future__ import annotations
 
+import fcntl
 import logging
 import math
 import random
@@ -706,6 +707,16 @@ def run_sleep_cycle(
         the dict includes ``dream_pending=True`` and the ``dream_id`` field
         will be None (it may or may not complete before the caller reads it).
     """
+    # Acquire advisory lock to prevent concurrent sleep cycles across sessions.
+    # Non-blocking: if another process holds the lock, skip this cycle.
+    lock_path = db_path + ".sleep.lock"
+    try:
+        lock_fd = open(lock_path, "w")
+        fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        logger.info("sleep: another cycle is already running — skipping")
+        return {}
+
     t_start = time.perf_counter()
     conn = sqlite3.connect(db_path)
     conn.execute("PRAGMA busy_timeout=5000")

--- a/plugins/memory/cashew/sleep_refactor.py
+++ b/plugins/memory/cashew/sleep_refactor.py
@@ -666,6 +666,7 @@ def _run_dream_async(
     def _task():
         try:
             conn = sqlite3.connect(db_path)
+            conn.execute("PRAGMA busy_timeout=5000")
             _set_wal(conn)
             dream_id = _generate_dream(conn, cross_link_tuples, model_fn=model_fn)
             orphans = _embed_orphans(conn, embedding_model=embedding_model)
@@ -707,6 +708,7 @@ def run_sleep_cycle(
     """
     t_start = time.perf_counter()
     conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA busy_timeout=5000")
     _set_wal(conn)
 
     # Select nodes for this cycle (oldest-first heuristic)


### PR DESCRIPTION
## Summary

Two defensive fixes for the sleep cycle to handle concurrent Hermes sessions:

- **busy_timeout (#52)**: Add `PRAGMA busy_timeout=5000` to both SQLite connections in `sleep_refactor.py` so transient lock contention doesn't fail the entire cycle
- **advisory lock (#54)**: Use `fcntl.flock(LOCK_EX | LOCK_NB)` on a sentinel file to ensure only one sleep cycle runs at a time across all Hermes processes. Non-blocking — if another session holds the lock, skip with an INFO log instead of racing

## Related Issues

Closes #52
Closes #54

## Test Plan

- [x] Sleep cycle tests pass (`pytest tests/test_sleep_refactor.py` — 39 passed, 3 skipped)
- [x] Full suite shows no regressions
- [x] Manual review: `flock` lock file auto-cleans up when holding process exits

## Breaking Changes

None — both changes are defensive and make existing behavior more robust under concurrent load.

Filed by Jasper (AI agent on behalf of Magnus Hedemark)
