### PR TITLE
fix: wire dream generation into scheduled sleep cycle

### DIFF
--- a/plugins/memory/cashew/__init__.py
+++ b/plugins/memory/cashew/__init__.py
@@ -22,6 +22,7 @@ from .config import (
     load_config,
     resolve_config_path,
     resolve_db_path,
+    resolve_model_fn,
     save_config as _config_save_config,
 )
 
@@ -584,106 +585,23 @@ class CashewMemoryProvider(MemoryProvider):
     # LLM integration via auxiliary.memory convention
     # ------------------------------------------------------------------
 
-    # Well-known provider-to-env-var mappings for API key resolution.
-    # Used when the auxiliary config does not explicitly provide an api_key.
-    _PROVIDER_ENV_MAP: dict[str, str] = {
-        "openai": "OPENAI_API_KEY",
-        "openrouter": "OPENROUTER_API_KEY",
-        "anthropic": "ANTHROPIC_API_KEY",
-        "opencode-go": "OPENCODE_GO_API_KEY",
-        "opencode-zen": "OPENCODE_ZEN_API_KEY",
-        "deepseek": "DEEPSEEK_API_KEY",
-        "google": "GOOGLE_API_KEY",
-        "xai": "XAI_API_KEY",
-        "github": "COPILOT_GITHUB_TOKEN",
-        "huggingface": "HF_TOKEN",
-    }
-
     def _build_model_fn(self) -> Callable[[str], str] | None:
         """Construct an LLM callable from the configured auxiliary.memory role.
 
-        Reads Hermes' own config.yaml to find the auxiliary.<role> section,
-        resolves the API key from config or well-known env vars, and returns
-        an OpenAI-compatible callable. Returns None when:
+        Delegates to ``config.resolve_model_fn()`` which reads Hermes'
+        ``config.yaml`` and resolves the API key from config or well-known
+        env vars. Returns None when:
         - No llm_aux_role is configured (heuristic-only mode)
         - The auxiliary section or API key cannot be found (logs warning)
         """
-        role = self._config.llm_aux_role if self._config else None
-        if not role:
+        if not self._config or not self._config.llm_aux_role:
             return None
-
-        config_path = self._hermes_home / "config.yaml" if self._hermes_home else pathlib.Path()
-        if not config_path or not config_path.exists():
-            logger.info(
-                "llm_aux_role=%r but %s not found; falling back to heuristic extraction",
-                role, config_path,
-            )
+        if self._hermes_home is None:
             return None
-
-        try:
-            import yaml
-            raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
-            aux_config = (raw or {}).get("auxiliary", {}).get(role, {})
-        except Exception:
-            logger.warning(
-                "llm_aux_role=%r: failed to parse %s; falling back to heuristic extraction",
-                role, config_path, exc_info=True,
-            )
-            return None
-
-        model = aux_config.get("model")
-        if not model:
-            logger.warning(
-                "llm_aux_role=%r: no model in auxiliary.%r config; "
-                "falling back to heuristic extraction", role, role,
-            )
-            return None
-
-        provider = aux_config.get("provider", "openai")
-        base_url = aux_config.get("base_url", "https://api.openai.com/v1").rstrip("/")
-
-        # Resolve API key: explicit config > env var by provider convention
-        api_key = aux_config.get("api_key")
-        if not api_key:
-            env_var = self._PROVIDER_ENV_MAP.get(provider)
-            if env_var:
-                api_key = os.environ.get(env_var)
-
-        if not api_key:
-            logger.warning(
-                "llm_aux_role=%r: no API key for provider=%r; "
-                "falling back to heuristic extraction", role, provider,
-            )
-            return None
-
-        logger.info(
-            "llm_aux_role=%r: using %s %s via %s",
-            role, provider, model, base_url,
+        return resolve_model_fn(
+            hermes_home=self._hermes_home,
+            config=self._config,
         )
-
-        def _model_fn(prompt: str) -> str:
-            """OpenAI-compatible chat completion callable for upstream cashew-brain."""
-            try:
-                import httpx
-                resp = httpx.post(
-                    f"{base_url}/chat/completions",
-                    json={
-                        "model": model,
-                        "messages": [{"role": "user", "content": prompt}],
-                    },
-                    headers={"Authorization": f"Bearer {api_key}"},
-                    timeout=120,
-                )
-                resp.raise_for_status()
-                return resp.json()["choices"][0]["message"]["content"]
-            except Exception:
-                logger.warning(
-                    "LLM call failed for llm_aux_role=%r (model=%s)",
-                    role, model, exc_info=True,
-                )
-                return ""
-
-        return _model_fn
 
     def sync_turn(self, user_content: str, assistant_content: str, session_id: str = "") -> None:
         """Hot-path enqueue of a completed turn (SYNC-01).

--- a/plugins/memory/cashew/config.py
+++ b/plugins/memory/cashew/config.py
@@ -16,7 +16,7 @@ import json
 import logging
 import os
 import pathlib
-from typing import Any
+from typing import Any, Callable
 
 logger = logging.getLogger(__name__)
 
@@ -410,6 +410,143 @@ def get_config_schema() -> list[dict[str, Any]]:
         },
     ]
     return schema
+
+
+_PROVIDER_ENV_MAP: dict[str, str] = {
+    "openai": "OPENAI_API_KEY",
+    "openrouter": "OPENROUTER_API_KEY",
+    "anthropic": "ANTHROPIC_API_KEY",
+    "opencode-go": "OPENCODE_GO_API_KEY",
+    "opencode-zen": "OPENCODE_ZEN_API_KEY",
+    "deepseek": "DEEPSEEK_API_KEY",
+    "google": "GOOGLE_API_KEY",
+    "xai": "XAI_API_KEY",
+    "github": "COPILOT_GITHUB_TOKEN",
+    "huggingface": "HF_TOKEN",
+}
+
+
+def _read_cashew_config(hermes_home: pathlib.Path) -> CashewConfig | None:
+    """Read cashew.json and return a CashewConfig, or None if absent/unparseable."""
+    cashew_path = resolve_config_path(hermes_home)
+    if not cashew_path.exists():
+        logger.debug("cashew.json not found at %s; cannot resolve model_fn", cashew_path)
+        return None
+    try:
+        return load_config(hermes_home)
+    except Exception:
+        logger.warning(
+            "Failed to load cashew.json from %s; cannot resolve model_fn",
+            cashew_path, exc_info=True,
+        )
+        return None
+
+
+def resolve_model_fn(
+    hermes_home: pathlib.Path,
+    config: CashewConfig | None = None,
+) -> Callable[[str], str] | None:
+    """Resolve an OpenAI-compatible LLM callable from Hermes auxiliary config.
+
+    Reads ``llm_aux_role`` from ``cashew.json`` (or the provided
+    *config*), then ``auxiliary.<role>`` from ``config.yaml``, resolves
+    the API key from config or well-known env vars, and returns an
+    ``httpx``-based callable suitable for dream generation and text
+    extraction.
+
+    Returns ``None`` when:
+    - No ``llm_aux_role`` is configured
+    - ``config.yaml`` is absent or unparseable
+    - The auxiliary section or API key cannot be found (logs warning)
+
+    Designed for use by both ``CashewMemoryProvider`` (which passes its
+    already-loaded ``CashewConfig``) and the sleep cron script (which
+    passes ``None`` and lets the function load ``cashew.json`` itself).
+    """
+    # Resolve llm_aux_role from config
+    if config is None:
+        config = _read_cashew_config(hermes_home)
+    if config is None:
+        return None
+
+    role = config.llm_aux_role
+    if not role:
+        logger.debug("llm_aux_role not set; heuristic-only mode — no model_fn")
+        return None
+
+    # Read auxiliary config from config.yaml
+    config_yaml_path = hermes_home / "config.yaml"
+    if not config_yaml_path.exists():
+        logger.info(
+            "llm_aux_role=%r but %s not found; falling back to heuristic extraction",
+            role, config_yaml_path,
+        )
+        return None
+
+    try:
+        import yaml
+        raw = yaml.safe_load(config_yaml_path.read_text(encoding="utf-8"))
+        aux_config = (raw or {}).get("auxiliary", {}).get(role, {})
+    except Exception:
+        logger.warning(
+            "llm_aux_role=%r: failed to parse %s; falling back to heuristic extraction",
+            role, config_yaml_path, exc_info=True,
+        )
+        return None
+
+    model = aux_config.get("model")
+    if not model:
+        logger.warning(
+            "llm_aux_role=%r: no model in auxiliary.%s config; "
+            "falling back to heuristic extraction", role, role,
+        )
+        return None
+
+    provider = aux_config.get("provider", "openai")
+    base_url = aux_config.get("base_url", "https://api.openai.com/v1").rstrip("/")
+
+    # Resolve API key: explicit config > env var by provider convention
+    api_key = aux_config.get("api_key")
+    if not api_key:
+        env_var = _PROVIDER_ENV_MAP.get(provider)
+        if env_var:
+            api_key = os.environ.get(env_var)
+
+    if not api_key:
+        logger.warning(
+            "llm_aux_role=%r: no API key for provider=%r; "
+            "falling back to heuristic extraction", role, provider,
+        )
+        return None
+
+    logger.info(
+        "llm_aux_role=%r: using %s %s via %s",
+        role, provider, model, base_url,
+    )
+
+    def _model_fn(prompt: str) -> str:
+        """OpenAI-compatible chat completion callable."""
+        try:
+            import httpx
+            resp = httpx.post(
+                f"{base_url}/chat/completions",
+                json={
+                    "model": model,
+                    "messages": [{"role": "user", "content": prompt}],
+                },
+                headers={"Authorization": f"Bearer {api_key}"},
+                timeout=120,
+            )
+            resp.raise_for_status()
+            return resp.json()["choices"][0]["message"]["content"]
+        except Exception:
+            logger.warning(
+                "LLM call failed for role=%r (model=%s)",
+                role, model, exc_info=True,
+            )
+            return ""
+
+    return _model_fn
 
 
 def resolve_config_path(hermes_home: str | os.PathLike[str]) -> pathlib.Path:

--- a/plugins/memory/cashew/sleep_cron_script.py
+++ b/plugins/memory/cashew/sleep_cron_script.py
@@ -84,10 +84,14 @@ def main() -> None:
         # Fallback: try the installed package (PyPI install path)
         from cashew_sleep_refactor import run_sleep_cycle  # type: ignore[import-not-found]
 
+    # Resolve the LLM callable from auxiliary config for dream generation (Phase 8).
+    from plugins.memory.cashew.config import resolve_model_fn as _resolve_model_fn
+    model_fn = _resolve_model_fn(hermes_home=hermes_home)
+
     result = run_sleep_cycle(
         db_path=db_path,
         limit=limit,
-        model_fn=None,
+        model_fn=model_fn,
         background_dream=True,
         embedding_model=embedding_model,
     )

--- a/plugins/memory/cashew/sleep_refactor.py
+++ b/plugins/memory/cashew/sleep_refactor.py
@@ -776,6 +776,7 @@ def run_sleep_cycle(
     # Phase 8: dream generation
     dream_id = None
     dream_pending = False
+    dream_status = "skipped"  # default when model_fn is None or no cross-source pairs
     if model_fn is not None and cross_link_tuples:
         if background_dream:
             _run_dream_async(
@@ -785,8 +786,12 @@ def run_sleep_cycle(
                 embedding_model=embedding_model,
             )
             dream_pending = True
+            dream_status = "pending"
         else:
             dream_id = _generate_dream(conn, cross_link_tuples, model_fn=model_fn)
+            dream_status = "ran" if dream_id else "failed"
+    elif model_fn is not None and not cross_link_tuples:
+        dream_status = "skipped"  # model available but no pairs
 
     # Phase 9: embed orphans
     if background_dream:
@@ -814,6 +819,7 @@ def run_sleep_cycle(
         "core_demoted": core_stats.get("demoted", 0),
         "dream_id": dream_id,
         "dream_pending": dream_pending,
+        "dream_generation": dream_status,
         "orphans_embedded": orphans,
         "total_nodes": len(metrics),
         "elapsed_s": elapsed,
@@ -834,7 +840,7 @@ def run_sleep_cycle(
     else:
         logger.info(
             "sleep: cycle complete in %.1fs — %d nodes, %d cross-links, %d dedups, "
-            "%d GC, %d permanent, %d core, %d dream, %d embedded",
+            "%d GC, %d permanent, %d core, dream=%s, %d embedded",
             elapsed,
             summary["total_nodes"],
             summary["cross_links_created"],
@@ -842,7 +848,7 @@ def run_sleep_cycle(
             summary["nodes_gc_decayed"],
             summary["nodes_made_permanent"],
             summary["core_promoted"],
-            1 if dream_id else 0,
+            dream_status,
             summary["orphans_embedded"],
         )
     return summary

--- a/tests/test_config_roundtrip.py
+++ b/tests/test_config_roundtrip.py
@@ -20,12 +20,14 @@ from plugins.memory.cashew.config import (
     DEFAULTS,
     ENV_VAR_MAP,
     _env_var_name,
+    _PROVIDER_ENV_MAP,
     get_ai_domain,
     get_config_schema,
     get_user_domain,
     load_config,
     resolve_config_path,
     resolve_db_path,
+    resolve_model_fn,
     save_config,
 )
 
@@ -347,3 +349,167 @@ def test_load_config_v0_1_0_four_key_file_gets_defaults_for_new_keys(tmp_path):
     assert cfg.auto_extraction == DEFAULTS["auto_extraction"]
     assert cfg.domain_classifications == list(DEFAULTS["domain_classifications"])
     assert cfg.gc_protect_types == list(DEFAULTS["gc_protect_types"])
+
+
+# ── resolve_model_fn tests ───────────────────────────────────────────────────
+
+
+def test_provider_env_map_has_all_entries():
+    """_PROVIDER_ENV_MAP covers all well-known providers."""
+    assert len(_PROVIDER_ENV_MAP) == 10
+    assert _PROVIDER_ENV_MAP["deepseek"] == "DEEPSEEK_API_KEY"
+    assert _PROVIDER_ENV_MAP["openai"] == "OPENAI_API_KEY"
+
+
+def test_resolve_model_fn_returns_none_when_no_cashew_json(tmp_path):
+    """No cashew.json → resolve_model_fn returns None."""
+    result = resolve_model_fn(tmp_path)
+    assert result is None
+
+
+def test_resolve_model_fn_returns_none_when_llm_role_empty(tmp_path):
+    """cashew.json exists but llm_aux_role is empty → None."""
+    hermes_home = tmp_path / "h1"
+    hermes_home.mkdir()
+    (hermes_home / "cashew.json").write_text(json.dumps({"llm_aux_role": ""}))
+    result = resolve_model_fn(hermes_home)
+    assert result is None
+
+
+def test_resolve_model_fn_returns_none_when_config_yaml_missing(tmp_path):
+    """cashew.json with llm_aux_role set, but no config.yaml → None."""
+    hermes_home = tmp_path / "h2"
+    hermes_home.mkdir()
+    (hermes_home / "cashew.json").write_text(
+        json.dumps({"llm_aux_role": "memory"})
+    )
+    result = resolve_model_fn(hermes_home)
+    assert result is None
+
+
+def test_resolve_model_fn_returns_none_when_aux_section_missing(tmp_path):
+    """config.yaml exists but has no auxiliary.memory section → None."""
+    hermes_home = tmp_path / "h3"
+    hermes_home.mkdir()
+    (hermes_home / "cashew.json").write_text(
+        json.dumps({"llm_aux_role": "memory"})
+    )
+    (hermes_home / "config.yaml").write_text("model:\n  provider: test\n")
+    result = resolve_model_fn(hermes_home)
+    assert result is None
+
+
+def test_resolve_model_fn_returns_none_when_no_model(tmp_path):
+    """auxiliary.memory exists but has no 'model' key → None."""
+    hermes_home = tmp_path / "h4"
+    hermes_home.mkdir()
+    (hermes_home / "cashew.json").write_text(
+        json.dumps({"llm_aux_role": "memory"})
+    )
+    (hermes_home / "config.yaml").write_text(
+        "auxiliary:\n  memory:\n    provider: deepseek\n"
+    )
+    result = resolve_model_fn(hermes_home)
+    assert result is None
+
+
+def test_resolve_model_fn_returns_none_when_no_api_key(tmp_path, monkeypatch):
+    """auxiliary.memory fully configured but no API key → None."""
+    hermes_home = tmp_path / "h5"
+    hermes_home.mkdir()
+    (hermes_home / "cashew.json").write_text(
+        json.dumps({"llm_aux_role": "memory"})
+    )
+    (hermes_home / "config.yaml").write_text(
+        "auxiliary:\n  memory:\n"
+        "    provider: deepseek\n"
+        "    model: deepseek-v4-flash\n"
+    )
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    result = resolve_model_fn(hermes_home)
+    assert result is None
+
+
+def test_resolve_model_fn_returns_callable_with_env_var(tmp_path, monkeypatch):
+    """Valid config + DEEPSEEK_API_KEY → returns callable."""
+    hermes_home = tmp_path / "h6"
+    hermes_home.mkdir()
+    (hermes_home / "cashew.json").write_text(
+        json.dumps({"llm_aux_role": "memory"})
+    )
+    (hermes_home / "config.yaml").write_text(
+        "auxiliary:\n  memory:\n"
+        "    provider: deepseek\n"
+        "    model: deepseek-v4-flash\n"
+        "    base_url: https://api.deepseek.com/v1\n"
+    )
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key-123")
+    result = resolve_model_fn(hermes_home)
+    assert result is not None
+    assert callable(result)
+
+
+def test_resolve_model_fn_returns_callable_with_explicit_api_key(tmp_path):
+    """API key in config.yaml (not env var) → returns callable."""
+    hermes_home = tmp_path / "h7"
+    hermes_home.mkdir()
+    (hermes_home / "cashew.json").write_text(
+        json.dumps({"llm_aux_role": "memory"})
+    )
+    (hermes_home / "config.yaml").write_text(
+        "auxiliary:\n  memory:\n"
+        "    provider: deepseek\n"
+        "    model: deepseek-v4-flash\n"
+        "    base_url: https://api.deepseek.com/v1\n"
+        "    api_key: inline-key-456\n"
+    )
+    result = resolve_model_fn(hermes_home)
+    assert result is not None
+    assert callable(result)
+
+
+def test_resolve_model_fn_accepts_passed_config(tmp_path, monkeypatch):
+    """Passing a CashewConfig avoids re-reading cashew.json."""
+    hermes_home = tmp_path / "h8"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "auxiliary:\n  memory:\n"
+        "    provider: deepseek\n"
+        "    model: deepseek-v4-flash\n"
+        "    base_url: https://api.deepseek.com/v1\n"
+    )
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key-789")
+    cfg = CashewConfig(llm_aux_role="memory")
+    result = resolve_model_fn(hermes_home, config=cfg)
+    assert result is not None
+    assert callable(result)
+
+
+def test_resolve_model_fn_graceful_on_corrupt_config_yaml(tmp_path):
+    """Corrupt config.yaml → returns None, does not raise."""
+    hermes_home = tmp_path / "h9"
+    hermes_home.mkdir()
+    (hermes_home / "cashew.json").write_text(
+        json.dumps({"llm_aux_role": "memory"})
+    )
+    (hermes_home / "config.yaml").write_text("::: not yaml :::")
+    result = resolve_model_fn(hermes_home)
+    assert result is None
+
+
+def test_resolve_model_fn_uses_default_base_url(tmp_path):
+    """No base_url in config → defaults to https://api.openai.com/v1."""
+    hermes_home = tmp_path / "h10"
+    hermes_home.mkdir()
+    (hermes_home / "cashew.json").write_text(
+        json.dumps({"llm_aux_role": "memory"})
+    )
+    (hermes_home / "config.yaml").write_text(
+        "auxiliary:\n  memory:\n"
+        "    provider: openai\n"
+        "    model: gpt-4\n"
+        "    api_key: sk-test\n"
+    )
+    result = resolve_model_fn(hermes_home)
+    assert result is not None
+    assert callable(result)

--- a/tests/test_sleep_cron_lifecycle.py
+++ b/tests/test_sleep_cron_lifecycle.py
@@ -278,3 +278,36 @@ def test_cron_script_is_installed(tmp_path, monkeypatch):
     assert "plugins.memory.cashew.sleep_refactor" in content
 
     provider.shutdown()
+
+
+def test_cron_script_imports_resolve_model_fn(tmp_path):
+    """The cron script imports resolve_model_fn and passes it to run_sleep_cycle."""
+    hermes_home = tmp_path / "h6"
+    hermes_home.mkdir()
+    cfg = hermes_home / "cashew.json"
+    config_yaml = hermes_home / "config.yaml"
+    config_yaml.write_text("model:\n  provider: test\n  default: test\n")
+    cfg.write_text(json.dumps(_make_config(hermes_home)))
+
+    (hermes_home / "cashew").mkdir(parents=True)
+    conn = sqlite3.connect(str(hermes_home / "cashew" / "brain.db"))
+    _ensure_schema(conn)
+    conn.close()
+
+    # Install the cron script
+    script_path = hermes_home / "scripts" / "cashew-sleep-cycle.py"
+    script_path.parent.mkdir(parents=True)
+    script_source = (Path(__file__).parent.parent / "plugins" / "memory"
+                     / "cashew" / "sleep_cron_script.py").read_text()
+    script_path.write_text(script_source)
+    script_path.chmod(0o755)
+
+    # Verify the script contains the resolve_model_fn import
+    assert "resolve_model_fn" in script_source
+    assert "model_fn = _resolve_model_fn" in script_source or \
+           "resolve_model_fn(hermes_home" in script_source
+    assert "model_fn=model_fn" in script_source
+    # No longer hardcoded None
+    assert "model_fn=None" not in script_source.replace(
+        "# model_fn=None (fallback)", ""
+    )

--- a/tests/test_sleep_refactor.py
+++ b/tests/test_sleep_refactor.py
@@ -718,7 +718,8 @@ def test_run_sleep_cycle_smoke(small_graph, monkeypatch):
         "dedup_components", "dedup_nodes_merged",
         "nodes_gc_decayed", "nodes_made_permanent",
         "core_promoted", "core_demoted",
-        "dream_id", "orphans_embedded",
+        "dream_id", "dream_pending", "dream_generation",
+        "orphans_embedded",
         "total_nodes", "elapsed_s",
     }
     for key in expected_keys:
@@ -1000,11 +1001,12 @@ def test_run_dream_async_handles_exception(small_graph):
 
 
 def test_background_dream_flag_requires_model_fn_and_tuples(small_graph, monkeypatch):
-    """background_dream=True without model_fn does not set dream_pending."""
+    """background_dream=True without model_fn sets dream_generation='skipped'."""
     result = run_sleep_cycle(small_graph, limit=6, model_fn=None,
                              background_dream=True)
     assert "dream_pending" in result
     assert result["dream_pending"] is False
+    assert result["dream_generation"] == "skipped"
 
 
 def test_background_dream_runs_sync_phases_before_returning(small_graph):
@@ -1019,7 +1021,7 @@ def test_background_dream_runs_sync_phases_before_returning(small_graph):
 
 
 def test_background_dream_false_maintains_legacy_behavior(small_graph):
-    """background_dream=False does not set dream_pending."""
+    """background_dream=False with model_fn runs dream synchronously."""
     def fake_model_fn(prompt: str) -> str:
         return "Legacy dream synthesis for testing."
 
@@ -1028,3 +1030,5 @@ def test_background_dream_false_maintains_legacy_behavior(small_graph):
     assert "dream_pending" in result
     assert result["dream_pending"] is False
     assert "dream_id" in result
+    assert "dream_generation" in result
+    assert result["dream_generation"] in ("ran", "skipped", "failed")


### PR DESCRIPTION
## Summary

- Extract LLM model_fn resolution into a standalone `resolve_model_fn()` function in `config.py`
- Wire the sleep cron script to resolve and pass model_fn, enabling dream generation (Phase 8) in scheduled mode
- Add `dream_generation` status field (`"skipped"` / `"pending"` / `"ran"` / `"failed"`) to the cycle summary
- Refactor `CashewMemoryProvider._build_model_fn()` to a thin delegation

## Related Issues

Closes #91

## Test Plan

- [x] Unit tests pass (`pytest`) — 235 passed, 4 skipped, 1 pre-existing failure deselected
- [x] New tests added for the change — 11 new `resolve_model_fn` tests in `test_config_roundtrip.py`, 1 new cron script test in `test_sleep_cron_lifecycle.py`, updated `test_sleep_refactor.py` assertions for `dream_generation` field
- [x] Manual verification (describe what was tested) — verified that `_build_model_fn()` produces identical results before/after refactor (same `auxiliary.memory` → same model callable), verified cron script import path resolves correctly

## Breaking Changes

None. The `dream_generation` field is additive in the cycle summary dict. Existing `dream_id` / `dream_pending` fields are preserved. If `resolve_model_fn()` returns `None` (no config / no API key), behavior is identical to prior `model_fn=None` — dream generation is skipped with `dream_generation: "skipped"` instead of the old silent null.

## Notes for Reviewers

- The `_PROVIDER_ENV_MAP` was moved from `CashewMemoryProvider._PROVIDER_ENV_MAP` (class attribute) to `config._PROVIDER_ENV_MAP` (module constant). Both the provider's `_build_model_fn()` and the cron script's `resolve_model_fn()` call share the same map.
- The existing `auxiliary.memory` config is reused — no new config keys. If a user has `llm_aux_role: "memory"` set and `auxiliary.memory` in `config.yaml`, dream generation will work in scheduled mode automatically.
- The pre-existing `test_vec_embeddings_guarded_when_unavailable` failure is unrelated (also fails on main).

Filed by Jasper (AI agent on behalf of Magnus Hedemark)
