### PR TITLE
fix: wire cross-source filtering and out-degree ordering in sleep cycle

### DIFF
--- a/plugins/memory/cashew/sleep_refactor.py
+++ b/plugins/memory/cashew/sleep_refactor.py
@@ -722,12 +722,15 @@ def run_sleep_cycle(
     conn.execute("PRAGMA busy_timeout=5000")
     _set_wal(conn)
 
-    # Select nodes for this cycle (oldest-first heuristic)
+    # Select nodes for this cycle (lowest-degree-first heuristic)
     rows = conn.execute(
         "SELECT e.node_id FROM embeddings e "
         "JOIN thought_nodes tn ON e.node_id = tn.id "
         "WHERE (tn.decayed IS NULL OR tn.decayed = 0) "
-        "ORDER BY tn.timestamp ASC "
+        "ORDER BY ("
+        "  SELECT COUNT(*) FROM derivation_edges "
+        "  WHERE parent_id = e.node_id OR child_id = e.node_id"
+        ") ASC, tn.timestamp ASC "
         "LIMIT ?",
         (limit,),
     ).fetchall()
@@ -748,7 +751,23 @@ def run_sleep_cycle(
     cross_stats = {"created": 0, "skipped": 0}
     cross_link_tuples: list[tuple[str, str, float]] = []
     if len(cross_pairs) > 0:
-        cross_stats = _batch_cross_links(conn, valid_ids, cross_pairs, sim)
+        # Resolve source_file for each valid node so _batch_cross_links can
+        # skip same-document pairs (which carry no graph-discovery value).
+        source_files: dict[str, str] = {}
+        for row in conn.execute(
+            "SELECT id, source_file FROM thought_nodes "
+            "WHERE id IN ({})".format(
+                ",".join(["?"] * len(valid_ids))
+            ),
+            valid_ids,
+        ).fetchall():
+            nid, sf = row
+            if sf:
+                source_files[nid] = sf
+        cross_stats = _batch_cross_links(
+            conn, valid_ids, cross_pairs, sim,
+            source_files=source_files or None,
+        )
         if model_fn is not None:
             for i, j in cross_pairs:
                 cross_link_tuples.append((


### PR DESCRIPTION
## Summary

- Wire `source_files` parameter into `run_sleep_cycle()` so cross-source filtering actually works (was a documented-but-never-wired feature)
- Change node selection from `ORDER BY tn.timestamp ASC` to degree-based ordering so low-connectivity nodes get processed first, spreading cross-links across the graph

## Related Issues

Closes #93
Closes #94

## Test Plan

- [x] Unit tests pass (`pytest`)
- [ ] New tests added for the change
- [x] Manual verification (describe what was tested)

### Fix 1 — Cross-source filtering

Before: `run_sleep_cycle()` called `_batch_cross_links(conn, valid_ids, cross_pairs, sim)` without `source_files`, so the filter logic was dead code. Same-document pairs from bulk imports were always processed as cross-context edges.

After: Node IDs are queried for `source_file` values before the cross-linking phase. The mapping is passed to `_batch_cross_links()`, which skips pairs where both nodes share the same non-empty `source_file`. Verified that the `same_source_skipped` counter in the cycle stats will now track skipped pairs.

### Fix 2 — Out-degree ordering

Before: `ORDER BY tn.timestamp ASC` — oldest import batches dominated every cycle.

After: `ORDER BY (SELECT COUNT(*) FROM derivation_edges WHERE parent_id = e.node_id OR child_id = e.node_id) ASC, tn.timestamp ASC` — nodes with fewer edges get processed first. Timestamp is the tiebreaker, so within the same degree tier, older nodes still take priority.

The correlated subquery reuses the same edge-counting pattern already used by `_compute_metrics()`.

## Breaking Changes

None — both changes are additive. The query ordering change may shift which nodes get cross-linked in a given cycle, but the total work per cycle is still capped by `MAX_NODES_PER_CYCLE` and `MAX_EDGES_PER_CYCLE`. No config keys changed.

## Notes for Reviewers

- The `source_files` resolution query runs against `valid_ids` (the subset of selected nodes that passed `_load_embedding_matrix`), not the full `ids` list. This is intentional — only nodes with valid embeddings are candidates for cross-linking.
- The out-degree ordering uses a correlated subquery rather than a pre-computed column. This avoids schema changes. For the work cap of 2,000 nodes per cycle, the subquery overhead is negligible compared to the similarity matrix computation.

---

Filed by Jasper (AI agent on behalf of Magnus Hedemark)