### PR TITLE
fix(config): resolve provider base_url from _PROVIDER_BASE_URLS map

### DIFF
--- a/plugins/memory/cashew/config.py
+++ b/plugins/memory/cashew/config.py
@@ -423,7 +423,32 @@ _PROVIDER_ENV_MAP: dict[str, str] = {
     "xai": "XAI_API_KEY",
     "github": "COPILOT_GITHUB_TOKEN",
     "huggingface": "HF_TOKEN",
+    "qwen": "QWEN_API_KEY",
+    "minimax": "MINIMAX_API_KEY",
+    "minimax-cn": "MINIMAX_CN_API_KEY",
+    "nvidia": "NVIDIA_API_KEY",
+    "ollama": "OLLAMA_API_KEY",
 }
+
+# Well-known inference base URLs for OpenAI-compatible providers.
+# Mirrors Hermes core's PROVIDER_REGISTRY inference_base_url values.
+# Used as fallback when auxiliary.<role>.base_url is missing or empty.
+_PROVIDER_BASE_URLS: dict[str, str] = {
+    "openai": "https://api.openai.com/v1",
+    "openrouter": "https://openrouter.ai/api/v1",
+    "opencode-zen": "https://opencode.ai/zen/v1",
+    "opencode-go": "https://opencode.ai/zen/go/v1",
+    "deepseek": "https://api.deepseek.com/v1",
+    "xai": "https://api.x.ai/v1",
+    "qwen": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+    "minimax": "https://api.minimaxi.chat/v1",
+    "minimax-cn": "https://api.minimax.chat/v1",
+    "nvidia": "https://integrate.api.nvidia.com/v1",
+    "ollama": "http://127.0.0.1:11434/v1",
+}
+# NOTE: "anthropic", "google", and "huggingface" are intentionally omitted.
+# They do not expose OpenAI-compatible /chat/completions endpoints natively;
+# users targeting them must set an explicit base_url in config.yaml.
 
 
 def _read_cashew_config(hermes_home: pathlib.Path) -> CashewConfig | None:
@@ -503,7 +528,10 @@ def resolve_model_fn(
         return None
 
     provider = aux_config.get("provider", "openai")
-    base_url = aux_config.get("base_url", "https://api.openai.com/v1").rstrip("/")
+    base_url = (
+        aux_config.get("base_url")
+        or _PROVIDER_BASE_URLS.get(provider, "https://api.openai.com/v1")
+    ).rstrip("/")
 
     # Resolve API key: explicit config > env var by provider convention
     api_key = aux_config.get("api_key")

--- a/tests/test_config_roundtrip.py
+++ b/tests/test_config_roundtrip.py
@@ -20,6 +20,7 @@ from plugins.memory.cashew.config import (
     DEFAULTS,
     ENV_VAR_MAP,
     _env_var_name,
+    _PROVIDER_BASE_URLS,
     _PROVIDER_ENV_MAP,
     get_ai_domain,
     get_config_schema,
@@ -356,9 +357,20 @@ def test_load_config_v0_1_0_four_key_file_gets_defaults_for_new_keys(tmp_path):
 
 def test_provider_env_map_has_all_entries():
     """_PROVIDER_ENV_MAP covers all well-known providers."""
-    assert len(_PROVIDER_ENV_MAP) == 10
+    assert len(_PROVIDER_ENV_MAP) == 15
     assert _PROVIDER_ENV_MAP["deepseek"] == "DEEPSEEK_API_KEY"
     assert _PROVIDER_ENV_MAP["openai"] == "OPENAI_API_KEY"
+
+
+def test_provider_base_urls_covers_openai_compatible_providers():
+    """_PROVIDER_BASE_URLS has known endpoints for all OpenAI-compatible providers."""
+    assert _PROVIDER_BASE_URLS["deepseek"] == "https://api.deepseek.com/v1"
+    assert _PROVIDER_BASE_URLS["opencode-zen"] == "https://opencode.ai/zen/v1"
+    assert _PROVIDER_BASE_URLS["opencode-go"] == "https://opencode.ai/zen/go/v1"
+    assert _PROVIDER_BASE_URLS["openrouter"] == "https://openrouter.ai/api/v1"
+    # Anthropic and Google are intentionally NOT in the map.
+    assert "anthropic" not in _PROVIDER_BASE_URLS
+    assert "google" not in _PROVIDER_BASE_URLS
 
 
 def test_resolve_model_fn_returns_none_when_no_cashew_json(tmp_path):
@@ -498,7 +510,7 @@ def test_resolve_model_fn_graceful_on_corrupt_config_yaml(tmp_path):
 
 
 def test_resolve_model_fn_uses_default_base_url(tmp_path):
-    """No base_url in config → defaults to https://api.openai.com/v1."""
+    """No base_url in config → defaults to provider's well-known URL."""
     hermes_home = tmp_path / "h10"
     hermes_home.mkdir()
     (hermes_home / "cashew.json").write_text(
@@ -512,4 +524,47 @@ def test_resolve_model_fn_uses_default_base_url(tmp_path):
     )
     result = resolve_model_fn(hermes_home)
     assert result is not None
-    assert callable(result)
+
+
+def test_resolve_model_fn_empty_base_url_resolves_to_provider_default(tmp_path, monkeypatch):
+    """base_url: '' (Hermes convention for 'use default') → provider's well-known URL."""
+    hermes_home = tmp_path / "h11"
+    hermes_home.mkdir()
+    (hermes_home / "cashew.json").write_text(
+        json.dumps({"llm_aux_role": "memory"})
+    )
+    (hermes_home / "config.yaml").write_text(
+        "auxiliary:\n  memory:\n"
+        "    provider: deepseek\n"
+        "    model: deepseek-v4-flash\n"
+        "    base_url: ''\n"
+    )
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key")
+    result = resolve_model_fn(hermes_home)
+    assert result is not None
+    # The base_url is captured as a string in the closure
+    captured = [v.cell_contents for v in result.__closure__ if isinstance(v.cell_contents, str)]
+    assert "https://api.deepseek.com/v1" in captured, (
+        f"Expected deepseek base_url in closure, got: {captured}"
+    )
+
+
+def test_resolve_model_fn_missing_base_url_uses_provider_map(tmp_path, monkeypatch):
+    """No base_url key at all for non-OpenAI provider → resolves from _PROVIDER_BASE_URLS."""
+    hermes_home = tmp_path / "h12"
+    hermes_home.mkdir()
+    (hermes_home / "cashew.json").write_text(
+        json.dumps({"llm_aux_role": "memory"})
+    )
+    (hermes_home / "config.yaml").write_text(
+        "auxiliary:\n  memory:\n"
+        "    provider: opencode-zen\n"
+        "    model: mimo-v2.5-free\n"
+    )
+    monkeypatch.setenv("OPENCODE_ZEN_API_KEY", "test-key")
+    result = resolve_model_fn(hermes_home)
+    assert result is not None
+    captured = [v.cell_contents for v in result.__closure__ if isinstance(v.cell_contents, str)]
+    assert "https://opencode.ai/zen/v1" in captured, (
+        f"Expected opencode-zen base_url in closure, got: {captured}"
+    )


### PR DESCRIPTION
## PR Body

Fixes #96.

## Summary

`resolve_model_fn()` in `plugins/memory/cashew/config.py` was hard-coding
`https://api.openai.com/v1` as the base URL when `auxiliary.<role>.base_url`
was missing from `config.yaml`, and returning an empty string when the key
was present but empty — both cases produced 401 errors against OpenAI for
any non-OpenAI provider.

### Root cause

The plugin had `_PROVIDER_ENV_MAP` for resolving API keys from env vars by
provider name, but no equivalent `_PROVIDER_BASE_URLS` map. Hermes core
handles this correctly via `PROVIDER_REGISTRY` in `hermes_cli/auth.py`, but
cashew reads the config independently.

### Fix

1. Added `_PROVIDER_BASE_URLS` dict with well-known inference endpoints for
   all OpenAI-compatible providers (OpenAI, OpenRouter, OpenCode Zen/Go,
   DeepSeek, xAI, Qwen, MiniMax, NVIDIA, Ollama). Anthropic and Google are
   intentionally omitted — they don't expose native `/chat/completions`
   endpoints.

2. Changed the resolution to use `or` so both `None` and `''` (the Hermes
   config.yaml convention for "use registry default") fall through to the
   provider map.

```python
# Before
base_url = aux_config.get("base_url", "https://api.openai.com/v1").rstrip("/")

# After
base_url = (
    aux_config.get("base_url")
    or _PROVIDER_BASE_URLS.get(provider, "https://api.openai.com/v1")
).rstrip("/")
```

## Files changed

- `plugins/memory/cashew/config.py` — added `_PROVIDER_BASE_URLS` map, fixed resolution logic
- `tests/test_config_roundtrip.py` — added `_PROVIDER_BASE_URLS` test, updated env map count,
  added 2 new tests for empty and missing `base_url` resolution

## QA

```
pytest tests/test_config_roundtrip.py -v → 45 passed
pytest tests/ -q → 236 passed, 3 failed (pre-existing, unrelated)
```

Pre-existing failures: `test_migration.py::test_vec_embeddings_guarded_when_unavailable`,
`test_no_home_leak.py::test_save_config_writes_only_under_tmp_path`,
`test_sync_worker.py::test_worker_processes_multiple_turns_fifo`.
All three are infrastructure/environment issues unrelated to this change.
