### PR TITLE
feat: make sqlite-vec a standard (not optional) dependency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,10 @@ done
 - **No `~/.hermes` writes.** All paths scope under `hermes_home`. Tests use `tmp_path` fixture.
 - **`sync_turn` must return <10 ms.** Bounded queue + non-daemon worker.
 - **Cashew dependency**: `cashew-brain>=1.1.0,<2.0.0` on PyPI.
-- **sqlite-vec** is an optional extra (`pip install hermes-cashew[vec]`). The plugin degrades gracefully without it (semantic search falls back to keyword + BFS), but the `vec_embeddings` virtual table migration is skipped. Install it for full semantic search capability.
+- **sqlite-vec** enables vector similarity search. It's a standard dependency
+  (not optional) — the plugin requires it. If your platform doesn't support
+  sqlite-vec's native extension, the plugin degrades gracefully to keyword + BFS
+  search (see logging on startup for the fallback message).
 - **`HF_HUB_OFFLINE=1`** set in `conftest.py` before any Cashew import. Embedding model must be mocked in tests.
 - **`CASHEW_*` env vars stripped** in `conftest.py` to prevent Hermes session leak into tests.
 - **Silent degrade** on all Cashew failures — log WARNING, return empty, never raise into Hermes.
@@ -106,7 +109,8 @@ done
 
 ```bash
 pip install -e ".[dev]"                # install with dev deps
-pip install -e ".[dev,vec]"            # install with dev deps + sqlite-vec
+pip install -e ".[dev]"                 # install with dev deps
+pip install -e .                        # minimal install
 pytest                                 # full suite
 pytest tests/test_name.py -xvs          # single file
 python3 -m pytest                       # macOS fallback
@@ -117,7 +121,7 @@ python3 -m pytest                       # macOS fallback
 Hermes runs from `~/.hermes/hermes-agent/venv/`. For dev installs in that venv, a symlink is needed:
 
 ```bash
-~/.hermes/hermes-agent/venv/bin/python3 -m pip install -e ".[dev,vec]"
+~/.hermes/hermes-agent/venv/bin/python3 -m pip install -e ".[dev]"
 ln -sf "$PWD/plugins/memory/cashew" ~/.hermes/hermes-agent/plugins/memory/cashew
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ vectorized cross-linking, batched DB writes, ~4s at 7K nodes.
 
 - [Hermes Agent](https://github.com/nousresearch/hermes-agent) installed
 - `cashew-brain>=1.0.0` — installed automatically by `hermes plugins install`
-- `sqlite-vec` — optional, enables semantic search (install below if wanted)
+- `sqlite-vec` — enables vector similarity search. Installed automatically.
 
 ## Install
 
@@ -152,8 +152,7 @@ Expected output shows `Provider: cashew` with `Plugin: installed` and `Status: a
 `hermes-cashew` provides two LLM-accessible tools:
 
 - **`cashew_query`** — searches the local thought graph for context relevant to
-  the current conversation. Uses sqlite-vec for semantic search when available,
-  with keyword fallback on macOS or when the extension is unavailable.
+  the current conversation. Uses sqlite-vec for semantic search.
 - **`cashew_extract`** — explicitly persists a conversation turn into the graph.
   The agent can call this when it judges a turn contains worth-remembering knowledge.
 
@@ -170,8 +169,7 @@ Nodes in the thought graph can carry tags. The `cashew_query` tool accepts an
 {"query": "prior decisions", "exclude_tags": ["vault:private"]}
 ```
 
-This works in both the upstream retrieval path (sqlite-vec / BFS) and the
-keyword fallback. Common use cases:
+This works in both the vector search and keyword fallback paths. Common use cases:
 
 - **Privacy**: Tag sensitive nodes with `vault:private` to exclude them from
   group or shared contexts
@@ -285,28 +283,19 @@ the API key dependency in a subprocess.
 | ``sleep_schedule`` | ``\"every 12h\"`` | Cron expression or interval string. Set to ``\"\"`` to disable cron-based scheduling entirely. Examples: ``\"every 30m\"``, ``\"0 */2 * * *\"``, ``\"0 3 * * *\"`` (daily at 3am). |
 | ``sleep_max_nodes`` | ``2000`` | Maximum number of nodes to cross-link in a single sleep cycle. Higher values converge faster but take longer per tick. |
 
-## Semantic Search (Optional)
+## Semantic Search
 
-`sqlite-vec` is an optional SQLite extension that enables vector similarity search.
-Without it, cashew falls back to keyword-based retrieval — still functional,
+`sqlite-vec` enables vector similarity search and is installed automatically as a
+standard dependency. If your platform doesn't support sqlite-vec's native extension,
+the plugin degrades gracefully to keyword-based retrieval — still functional,
 but less precise.
 
-**Install:**
-```bash
-pip install sqlite-vec
-```
-
-You may also need to enable load extension support in your SQLite build:
-```bash
-sqlite3_config(SQLITE_ENABLE_LOAD_EXTENSION)
-```
-
-If sqlite-vec is not available at runtime, you'll see this INFO log on startup:
+When sqlite-vec is not available at runtime, you'll see this log on startup:
 ```
 sqlite-vec not available; semantic search will use fallback
 ```
 
-This is normal and expected on systems without sqlite-vec support.
+This is normal — the plugin continues operating with keyword + BFS fallback.
 
 ## Uninstall
 

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -7,6 +7,7 @@ version: 0.9.0
 description: "Cashew — persistent thought-graph memory with local embeddings, organic decay, and autonomous think cycles."
 pip_dependencies:
   - "cashew-brain"
+  - "sqlite-vec"
 requires_env: []
 hooks:
   - on_session_end

--- a/plugins/memory/cashew/__init__.py
+++ b/plugins/memory/cashew/__init__.py
@@ -712,7 +712,7 @@ class CashewMemoryProvider(MemoryProvider):
                 except (ImportError, AttributeError):
                     conn.load_extension("vec0")
             except Exception:
-                pass  # sqlite-vec not available; individual callers handle their own fallback
+                pass  # sqlite-vec not available at platform level; graceful degradation active
             self._migrate_vec_embeddings(conn)
             self._create_vec_embeddings(conn)
             # Hermes provider metadata store (persistent counters, flags)
@@ -752,7 +752,7 @@ class CashewMemoryProvider(MemoryProvider):
                 logger.info("Migrating vec_embeddings from old schema (dropping and recreating)")
                 conn.execute("DROP TABLE vec_embeddings")
         except Exception:
-            logger.info("sqlite-vec not available; skipping vec_embeddings migration")
+            logger.info("sqlite-vec extension failed to load; vec_embeddings migration skipped")
 
 
 
@@ -784,7 +784,7 @@ class CashewMemoryProvider(MemoryProvider):
             """)
             logger.debug(f"vec_embeddings virtual table ready (dim={dim})")
         except Exception:
-            logger.info("sqlite-vec not available; semantic search will use fallback")
+            logger.info("sqlite-vec extension failed to load; semantic search will use fallback")
 
     def _enrich_results(self, node_ids: list[str]) -> list[dict]:
         """Fetch full node dicts from DB for upstream retrieval results.

--- a/plugins/memory/cashew/plugin.yaml
+++ b/plugins/memory/cashew/plugin.yaml
@@ -7,6 +7,7 @@ version: 0.9.0
 description: "Cashew — persistent thought-graph memory with local embeddings, organic decay, and autonomous think cycles."
 pip_dependencies:
   - "cashew-brain"
+  - "sqlite-vec"
 requires_env: []
 hooks:
   - on_session_end

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ requires-python = ">=3.10"
 authors = [{ name = "Magnus Hedemark", email = "magnus919@pm.me" }]
 dependencies = [
     "cashew-brain>=1.1.0,<2.0.0",
+    "sqlite-vec",
 ]
 
 [project.optional-dependencies]
@@ -22,9 +23,6 @@ dev = [
     "jsonschema>=4.18,<5",
     "PyYAML>=6.0",
     "build>=1.0",
-]
-vec = [
-    "sqlite-vec",
 ]
 
 [project.entry-points."hermes_agent.plugins"]


### PR DESCRIPTION
## Summary

sqlite-vec was previously an optional extra under `[project.optional-dependencies] vec`, requiring users to discover and run `pip install hermes-cashew[vec]` separately. This meant most installs ran without vector search.

## Changes

6 files changed, 22 insertions, 29 deletions

| File | Change |
|------|--------|
| `pyproject.toml` | Move sqlite-vec to core dependencies; remove stale `[vec]` extras |
| `plugin.yaml` (root) | Add sqlite-vec to `pip_dependencies` |
| `plugins/memory/cashew/plugin.yaml` | Add sqlite-vec to `pip_dependencies` |
| `AGENTS.md` | Remove `[vec]` references, document graceful degradation |
| `README.md` | Remove 'optional' install section, simplify to reflect standard dep |
| `__init__.py` | Update log messages from 'not available' → 'extension failed to load' |

## Backward Compatibility

The existing graceful degradation path (`except Exception: pass` in `_ensure_db_schema`) is preserved. If sqlite-vec's native extension can't load on a given platform, the plugin falls back to keyword + BFS search — the same behavior as before, just with the package always installed.

## Verification

- sqlite-vec 0.1.9 installed and importable in Hermes venv
- vec0 virtual table creates successfully with 1024-dim cosine distance
- CashewMemoryProvider imports cleanly with sqlite-vec available