### PR TITLE
fix: add pre-commit hooks, dependabot, CODEOWNERS, type checker, coverage tracking

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# Default owner for all files
+* @magnus919
+
+# Core plugin implementation
+/plugins/memory/cashew/ @magnus919
+
+# Tests
+/tests/ @magnus919
+
+# CI/CD configuration
+/.github/workflows/ @magnus919
+
+# Project configuration
+/pyproject.toml @magnus919
+/plugin.yaml @magnus919

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "ci(deps)"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,10 +34,16 @@ jobs:
       - name: Lint with ruff
         run: ruff check plugins/memory/cashew/ tests/ --output-format=github
 
-      - name: Run tests (capture log for offline-download scan)
+      - name: Run tests with coverage (capture log for offline-download scan)
         run: |
           set -o pipefail
-          pytest -xvs 2>&1 | tee pytest.log
+          pytest -xvs --cov=plugins/memory/cashew --cov-report=term --cov-report=xml --cov-fail-under=65 2>&1 | tee pytest.log
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage.xml
 
       - name: CI-03 — fail if embedding model was downloaded
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.0
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+        args: [--maxkb=500]
+      - id: check-merge-conflict
+      - id: detect-private-key

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,12 +18,15 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest>=8.2,<10",
+    "pytest-cov>=4.1,<6",
     "pytest-asyncio>=1.3",
     "pytest-mock>=3.15",
     "jsonschema>=4.18,<5",
     "PyYAML>=6.0",
     "build>=1.0",
     "ruff>=0.4,<1",
+    "mypy>=1.8,<2",
+    "pre-commit>=3.6,<4",
 ]
 
 [project.entry-points."hermes_agent.plugins"]
@@ -46,13 +49,41 @@ packages = ["plugins"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+addopts = "--durations=10"
 
 [tool.ruff]
 target-version = "py310"
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I"]
-ignore = ["E501"]
+select = ["E", "F", "N", "W", "I"]
+ignore = ["E501", "N802", "N806"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["N801", "N999"]
+"__init__.py" = ["N999"]
 
 [tool.ruff.format]
 line-ending = "lf"
+
+[tool.mypy]
+python_version = "3.10"
+strict = false
+warn_unused_configs = true
+warn_redundant_casts = true
+warn_unreachable = true
+ignore_missing_imports = true
+disallow_untyped_defs = false
+disallow_incomplete_defs = false
+check_untyped_defs = false
+
+[[tool.mypy.overrides]]
+module = "tests/*"
+ignore_errors = true
+
+[[tool.mypy.overrides]]
+module = "plugins.memory.cashew.verify"
+ignore_errors = true
+
+[[tool.mypy.overrides]]
+module = "plugins.memory.cashew.sleep_cron_script"
+ignore_errors = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ def _clear_cashew_env_vars(monkeypatch: pytest.MonkeyPatch):
         if key.startswith("CASHEW_"):
             monkeypatch.delenv(key, raising=False)
 
+
 # Synthesize agent.memory_provider if hermes-agent is not installed.
 # Verified minimal contract: MemoryProvider has `name` property and a set of abstract methods.
 # We only need the ABC to be importable — actual method signatures are exercised by Hermes at runtime.
@@ -109,15 +110,24 @@ def fake_embedder(monkeypatch):
     `raising=False` makes each patch a no-op if that attribute is absent on the current Cashew version —
     the fixture is belt-and-suspenders, not a pinned-version contract.
     """
+
     def _stub(*args, **kwargs):
         raise RuntimeError(
             "Real embedding load blocked in tests. Use a fixture-provided stub retriever."
         )
+
     try:
         import core.embeddings  # noqa: F401
-        for attr in ("load_embeddings", "load_all_embeddings", "embed_text", "embed_nodes"):
+
+        for attr in (
+            "load_embeddings",
+            "load_all_embeddings",
+            "embed_text",
+            "embed_nodes",
+        ):
             monkeypatch.setattr(f"core.embeddings.{attr}", _stub, raising=False)
         import core.session  # noqa: F401
+
         for attr in ("embed_text", "embed_nodes"):
             monkeypatch.setattr(f"core.session.{attr}", _stub, raising=False)
     except ImportError:
@@ -133,12 +143,12 @@ def _mock_heavy_imports(monkeypatch: pytest.MonkeyPatch):
     """
     import numpy as np
 
-    def _numpy_cosine_similarity(X: np.ndarray) -> np.ndarray:
+    def _numpy_cosine_similarity(x: np.ndarray) -> np.ndarray:
         """Pure numpy cosine similarity — replaces sklearn for tests."""
-        norms = np.linalg.norm(X, axis=1, keepdims=True)
+        norms = np.linalg.norm(x, axis=1, keepdims=True)
         norms[norms == 0] = 1.0
-        X_norm = X / norms
-        return np.dot(X_norm, X_norm.T)
+        x_norm = x / norms
+        return np.dot(x_norm, x_norm.T)
 
     class _FakeSentenceTransformer:
         """No-op SentenceTransformer that returns deterministic embeddings."""
@@ -146,7 +156,9 @@ def _mock_heavy_imports(monkeypatch: pytest.MonkeyPatch):
         def __init__(self, model_name: str = ""):
             self.model_name = model_name
 
-        def encode(self, texts, normalize_embeddings: bool = True, **kwargs) -> np.ndarray:
+        def encode(
+            self, texts, normalize_embeddings: bool = True, **kwargs
+        ) -> np.ndarray:
             if isinstance(texts, str):
                 texts = [texts]
             # Deterministic: hash-based embedding
@@ -171,6 +183,7 @@ def _mock_heavy_imports(monkeypatch: pytest.MonkeyPatch):
 
     # Mock SentenceTransformer at the import level — used inside _embed_orphans()
     import sys
+
     _had_st = "sentence_transformers" in sys.modules
     _saved_st = sys.modules.get("sentence_transformers")
     fake_st_module = type(sys)("sentence_transformers")
@@ -203,6 +216,7 @@ def home_snapshot():
     Never creates files under ~ — purely observational.
     """
     import pathlib
+
     home_hermes = pathlib.Path.home() / ".hermes"
 
     def _snapshot():
@@ -211,8 +225,7 @@ def home_snapshot():
         files = frozenset(
             p.relative_to(home_hermes).as_posix()
             for p in home_hermes.rglob("*")
-            if p.is_file()
-            and not p.name.endswith((".db-wal", ".db-shm"))
+            if p.is_file() and not p.name.endswith((".db-wal", ".db-shm"))
         )
         return {"exists": True, "files": files}
 
@@ -226,8 +239,12 @@ def home_snapshot():
         if pre["exists"]:
             new_files = post["files"] - pre["files"]
             removed_files = pre["files"] - post["files"]
-            assert not new_files, f"~/.hermes gained files during test: {sorted(new_files)}"
-            assert not removed_files, f"~/.hermes lost files during test: {sorted(removed_files)}"
+            assert not new_files, (
+                f"~/.hermes gained files during test: {sorted(new_files)}"
+            )
+            assert not removed_files, (
+                f"~/.hermes lost files during test: {sorted(removed_files)}"
+            )
 
     yield {"pre": pre, "assert_unchanged": assert_unchanged}
     assert_unchanged()


### PR DESCRIPTION
Addresses the top 3 action items from the Agent Readiness evaluation.

1. **Pre-commit hooks + type checker**: .pre-commit-config.yaml with ruff lint/format and standard hooks. Added mypy config to pyproject.toml.
2. **Dependabot + CODEOWNERS**: GitHub Dependabot for pip and actions updates. CODEOWNERS file mapping ownership.
3. **Test coverage + performance tracking**: pytest-cov with --cov-fail-under=65 in CI. --durations=10 in pytest config.