### PR TITLE
ci(tests): switch to self-hosted runner on saru

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, hermes-cashew, docker]
     env:
       HF_HUB_OFFLINE: "1"
       TRANSFORMERS_OFFLINE: "1"
@@ -95,7 +95,7 @@ jobs:
           echo "Optimizations: uv resolver (10x faster than pip), pytest-xvs (fail-fast)"
 
   wheel-smoke:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, hermes-cashew, docker]
     needs: test
     env:
       HF_HUB_OFFLINE: "1"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,9 @@ concurrency:
 
 jobs:
   test:
-    runs-on: [self-hosted, linux, x64, hermes-cashew, docker]
+    # Use self-hosted runner for same-repo PRs and pushes; GitHub-hosted for fork PRs
+    # (fork PRs on self-hosted runners are a security risk — arbitrary code execution)
+    runs-on: ${{ fromJSON(github.event.pull_request.head.repo.fork && '["ubuntu-latest"]' || '["self-hosted","linux","x64","hermes-cashew","docker"]') }}
     env:
       HF_HUB_OFFLINE: "1"
       TRANSFORMERS_OFFLINE: "1"
@@ -95,7 +97,8 @@ jobs:
           echo "Optimizations: uv resolver (10x faster than pip), pytest-xvs (fail-fast)"
 
   wheel-smoke:
-    runs-on: [self-hosted, linux, x64, hermes-cashew, docker]
+    # Same fork-conditional as test job above
+    runs-on: ${{ fromJSON(github.event.pull_request.head.repo.fork && '["ubuntu-latest"]' || '["self-hosted","linux","x64","hermes-cashew","docker"]') }}
     needs: test
     env:
       HF_HUB_OFFLINE: "1"


### PR DESCRIPTION
## Summary

Switch the Tests workflow from \`ubuntu-latest\` (GitHub-hosted) to the \`saru-hermes-cashew\` self-hosted runner on the homelab.

## Changes

- \`tests.yml\`: Changed \`runs-on\` from \`ubuntu-latest\` to \`[self-hosted, linux, x64, hermes-cashew, docker]\` in both the \`test\` and \`wheel-smoke\` jobs

## Benefits

- **Faster CI** — no cold-start VM provisioning (~30s saved per run)
- **Persistent cache** — uv cache and Python binaries persist across runs on the runner volume
- **Docker socket** — available for integration tests that spin up containers
- **Dedicated resource** — no contention with other repos on shared GitHub-hosted runners

## Runner details

- Container: \`myoung34/github-runner:latest\` on saru
- Labels: \`self-hosted, linux, x64, hermes-cashew, docker\`
- Python versions downloaded by \`actions/setup-python@v5\` on first use (~10-15s per version)

## Verification

- [ ] Push triggers CI on this PR — verify runner picks it up
- [ ] All tests pass on the self-hosted runner
- [ ] wheel-smoke job completes

Closes #118 (Phase 1)

Filed by Jasper (AI agent on behalf of Magnus Hedemark)