### PR TITLE
fix(config): contain database paths within profile

### DIFF
--- a/plugins/memory/cashew/__init__.py
+++ b/plugins/memory/cashew/__init__.py
@@ -156,7 +156,7 @@ def _ensure_auxiliary_memory(hermes_home: pathlib.Path) -> None:
         return
 
     try:
-        import yaml  # type: ignore[import-untyped]
+        import yaml  # type: ignore[import-untyped, unused-ignore]
 
         raw = config_path.read_text(encoding="utf-8")
         data = yaml.safe_load(raw) or {}

--- a/plugins/memory/cashew/config.py
+++ b/plugins/memory/cashew/config.py
@@ -552,7 +552,7 @@ def resolve_model_fn(
         return None
 
     try:
-        import yaml  # type: ignore[import-untyped]
+        import yaml  # type: ignore[import-untyped, unused-ignore]
 
         raw = yaml.safe_load(config_yaml_path.read_text(encoding="utf-8"))
         aux_config = (raw or {}).get("auxiliary", {}).get(role, {})

--- a/plugins/memory/cashew/config.py
+++ b/plugins/memory/cashew/config.py
@@ -654,7 +654,17 @@ def resolve_db_path(
             f"cashew_db_path must be relative to hermes_home; got absolute path {db_path_value!r}. "
             "Configure a relative path (e.g. 'cashew/brain.db') instead."
         )
-    return pathlib.Path(hermes_home) / db_path_value
+
+    home = pathlib.Path(hermes_home).resolve()
+    candidate = (home / db_path_value).resolve()
+    try:
+        candidate.relative_to(home)
+    except ValueError as exc:
+        raise ValueError(
+            "cashew_db_path must stay within hermes_home; "
+            f"got path {db_path_value!r} which resolves outside {str(home)!r}."
+        ) from exc
+    return candidate
 
 
 def load_config(hermes_home: str | os.PathLike[str]) -> CashewConfig:

--- a/plugins/memory/cashew/sleep_cron_script.py
+++ b/plugins/memory/cashew/sleep_cron_script.py
@@ -46,21 +46,17 @@ def _read_config(hermes_home: Path) -> dict:
 
 
 def _resolve_db_path(hermes_home: Path, config: dict) -> str:
-    """Resolve db path: absolute stays, relative rooted at hermes_home."""
-    default_db = str(hermes_home / "cashew" / "brain.db")
-    raw = config.get("cashew_db_path", "")
-    if not raw:
-        return default_db
-    if Path(raw).is_absolute():
-        return raw
-    return str(hermes_home / raw)
+    """Resolve the DB path through the provider's profile-isolation guard."""
+    from plugins.memory.cashew.config import resolve_db_path
+
+    raw = config.get("cashew_db_path") or "cashew/brain.db"
+    return str(resolve_db_path(hermes_home, raw))
 
 
 def main() -> None:
     """Discover config, import sleep_refactor, run one cycle, print JSON."""
     hermes_home = _find_hermes_home()
     config = _read_config(hermes_home)
-    db_path = _resolve_db_path(hermes_home, config)
     limit = config.get("sleep_max_nodes", 2000)
     embedding_model = config.get("embedding_model", "thenlper/gte-large")
 
@@ -78,6 +74,8 @@ def main() -> None:
             sys.path.insert(0, str(candidate.resolve()))
             break
 
+    db_path = _resolve_db_path(hermes_home, config)
+
     try:
         from plugins.memory.cashew.sleep_refactor import run_sleep_cycle
     except ImportError:
@@ -88,6 +86,7 @@ def main() -> None:
 
     # Resolve the LLM callable from auxiliary config for dream generation.
     from plugins.memory.cashew.config import resolve_model_fn as _resolve_model_fn
+
     model_fn = _resolve_model_fn(hermes_home=hermes_home)
 
     result = run_sleep_cycle(

--- a/tests/test_config_roundtrip.py
+++ b/tests/test_config_roundtrip.py
@@ -174,6 +174,16 @@ def test_resolve_db_path_allows_nested_profile_path(tmp_path):
     assert resolve_db_path(tmp_path, "nested/cashew/brain.db") == expected
 
 
+def test_cron_script_db_path_uses_profile_isolation_guard(tmp_path):
+    """The standalone cron path must reject the same escapes as the provider."""
+    from plugins.memory.cashew.sleep_cron_script import _resolve_db_path
+
+    with pytest.raises(ValueError, match="must stay within hermes_home"):
+        _resolve_db_path(tmp_path, {"cashew_db_path": "../outside.db"})
+
+    assert _resolve_db_path(tmp_path, {}) == str(tmp_path / "cashew" / "brain.db")
+
+
 def test_load_config_returns_defaults_when_file_absent(tmp_path):
     """No cashew.json → defaults for all 30 keys. No exception."""
     cfg = load_config(tmp_path)

--- a/tests/test_config_roundtrip.py
+++ b/tests/test_config_roundtrip.py
@@ -151,6 +151,29 @@ def test_resolve_db_path_rejects_absolute_paths(tmp_path):
     assert "/etc/passwd" in str(exc.value)
 
 
+def test_resolve_db_path_rejects_parent_traversal(tmp_path):
+    """CONF-04: relative paths must not traverse above hermes_home."""
+    with pytest.raises(ValueError, match="must stay within hermes_home"):
+        resolve_db_path(tmp_path, "../outside.db")
+
+
+def test_resolve_db_path_rejects_symlink_escape(tmp_path):
+    """CONF-04: an in-profile symlink must not redirect the DB outside."""
+    outside = tmp_path.parent / "outside"
+    outside.mkdir(exist_ok=True)
+    (tmp_path / "linked").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="must stay within hermes_home"):
+        resolve_db_path(tmp_path, "linked/brain.db")
+
+
+def test_resolve_db_path_allows_nested_profile_path(tmp_path):
+    """CONF-03: ordinary nested paths still resolve below hermes_home."""
+    expected = tmp_path / "nested" / "cashew" / "brain.db"
+
+    assert resolve_db_path(tmp_path, "nested/cashew/brain.db") == expected
+
+
 def test_load_config_returns_defaults_when_file_absent(tmp_path):
     """No cashew.json → defaults for all 30 keys. No exception."""
     cfg = load_config(tmp_path)


### PR DESCRIPTION
## Summary

<!-- 1-3 bullet points describing what this PR does and why -->

- Resolve the configured database path before use and reject candidates outside the active `hermes_home`.
- Cover both lexical parent traversal and symlink-parent escapes while preserving valid nested profile paths.

## Related Issues

<!-- Link to any related issues using Closes #N, Fixes #N, or similar -->

Closes #122

## Test Plan

<!-- How was this tested? Checklist of verification steps -->

- [x] Unit tests pass (`pytest`)
  - 240 passed, 5 skipped
- [x] New tests added for the change
- [x] Manual verification (describe what was tested)
  - Confirmed `../outside.db` raises `ValueError` while `cashew/brain.db` resolves normally.

## Breaking Changes

<!-- If this PR changes behavior, config keys, or API surfaces, describe what downstream consumers need to know -->

Invalid `cashew_db_path` values that previously escaped `hermes_home` through `..` or a symlink are now rejected. Valid in-profile relative paths are unchanged.

## Notes for Reviewers

<!-- Anything reviewers should pay special attention to, architecture decisions made, trade-offs considered, etc. -->

Scope assessment: both configuration-file and `CASHEW_DB_PATH` inputs converge on `resolve_db_path()`, so the containment check covers initialization from either source. `resolve()` also evaluates existing parent symlinks, preventing a path that is lexically inside the profile from redirecting SQLite outside it.

Local gates: Ruff, mypy, deptry, duplicate detection, dead-flag detection, focused profile-isolation tests, and the full suite passed. Graphify was refreshed after the code change.

Submitted by Codex (AI agent on behalf of Magnus Hedemark).
