### PR TITLE
fix(sync): drain accepted turns during shutdown

### DIFF
--- a/plugins/memory/cashew/__init__.py
+++ b/plugins/memory/cashew/__init__.py
@@ -374,6 +374,9 @@ class CashewMemoryProvider(MemoryProvider):  # type: ignore[misc]
         self._sync_queue: queue.Queue | None = None
         self._session_id: str = ""
         self._sync_worker: "threading.Thread | None" = None
+        # Serializes producer admission with sentinel insertion so no turn can
+        # race behind the shutdown sentinel and remain unprocessed.
+        self._sync_state_lock = threading.Lock()
         # Non-daemon worker that drains _sync_queue. Started in
         # initialize() only on happy path. Joined in shutdown()
         # with bounded timeout.
@@ -398,10 +401,12 @@ class CashewMemoryProvider(MemoryProvider):  # type: ignore[misc]
         # _register_sleep_cron(), cleared in shutdown(). None when
         # sleep scheduling is disabled or registration failed.
         self._sleep_cron_job_id: str | None = None
-        # Shutdown flag: set by shutdown() before the sentinel is posted, and
-        # checked by _drain_once to abort early if the interpreter is shutting
-        # down (avoids RuntimeError from sentence-transformers' atexit handler
-        # racing with Python's shutdown sequence).
+        # Stop accepting new turns once shutdown begins while allowing turns
+        # already ahead of the sentinel to drain normally.
+        self._shutdown_started = threading.Event()
+        # Interpreter-finalization flag: set only after sentence-transformers
+        # reports that Python's atexit sequence has begun. Unlike normal
+        # shutdown, this is unrecoverable and remaining queued turns must stop.
         self._shutdown_flag = threading.Event()
 
     @property
@@ -459,9 +464,12 @@ class CashewMemoryProvider(MemoryProvider):  # type: ignore[misc]
         self._session_id = session_id
         self._hermes_home = pathlib.Path(kwargs["hermes_home"])
         # Queue is created here so config-driven sizing/timeout values are wired in.
-        # The non-daemon worker thread drains it (see CLAUDE.md ### Threading Rule).
+        # The daemon worker thread drains it and receives a bounded flush during
+        # provider shutdown.
         self._sync_queue = queue.Queue(maxsize=16)
-        # Reset shutdown flag — a prior shutdown() may have set it.
+        # Reset lifecycle flags — a provider instance may be initialized again
+        # after a prior shutdown.
+        self._shutdown_started.clear()
         self._shutdown_flag.clear()
         with trace_operation("cashew.initialize") as span:
             span.set_attribute("session_id", session_id)
@@ -536,10 +544,11 @@ class CashewMemoryProvider(MemoryProvider):  # type: ignore[misc]
                 self._sync_worker = None
 
     def _start_sync_worker(self) -> None:
-        """Launch the non-daemon worker. Called from initialize() only on happy path.
+        """Launch the daemon worker. Called from initialize() only on happy path.
 
         MUST run AFTER self._db_path / self._session_id / self._sync_queue are set.
-        daemon=False is load-bearing (see CLAUDE.md Threading Rule).
+        The shutdown sentinel and bounded join provide the normal drain path;
+        daemon=True prevents a wedged dependency from blocking interpreter exit.
         """
         self._sync_worker = threading.Thread(
             target=self._worker_loop,
@@ -688,35 +697,37 @@ class CashewMemoryProvider(MemoryProvider):  # type: ignore[misc]
 
         Half-state (_sync_queue is None) is a silent no-op.
         """
-        # Buffer assistant content for queue_prefetch cue extraction.
-        # Must happen BEFORE the half-state guard so the most recent turn's
-        # assistant content is always available, even if the queue is not.
-        if assistant_content:
-            self._last_assistant = assistant_content
-        if self._sync_queue is None:
-            return  # not initialized or silent-degraded; no worker to feed
-        turn = (user_content, assistant_content, session_id)
-        try:
-            self._sync_queue.put_nowait(turn)
-        except queue.Full:
-            # Drop-oldest policy.
+        with self._sync_state_lock:
+            if self._shutdown_started.is_set() or self._sync_queue is None:
+                return
+            # Buffer assistant content for queue_prefetch cue extraction only
+            # after the turn has been admitted.
+            if assistant_content:
+                self._last_assistant = assistant_content
+            q = self._sync_queue
+            turn = (user_content, assistant_content, session_id)
             try:
-                self._sync_queue.get_nowait()
-                self._sync_queue.task_done()  # balance the drop (exactly once)
-            except queue.Empty:
-                pass  # worker drained between Full and get_nowait — rare race; no-op
-            self._dropped_turn_count += 1
-            _METRICS.record_sync_dropped()
-            logger.warning(
-                "cashew sync queue overflow (maxsize=%d); dropped oldest turn",
-                self._sync_queue.maxsize,
-            )
-            try:
-                self._sync_queue.put_nowait(turn)
+                q.put_nowait(turn)
             except queue.Full:
+                # Drop-oldest policy.
+                try:
+                    q.get_nowait()
+                    q.task_done()  # balance the drop (exactly once)
+                except queue.Empty:
+                    pass  # worker drained between Full and get_nowait — rare race
+                self._dropped_turn_count += 1
+                _METRICS.record_sync_dropped()
                 logger.warning(
-                    "cashew sync queue still full after drop-oldest; dropping new turn"
+                    "cashew sync queue overflow (maxsize=%d); dropped oldest turn",
+                    q.maxsize,
                 )
+                try:
+                    q.put_nowait(turn)
+                except queue.Full:
+                    logger.warning(
+                        "cashew sync queue still full after drop-oldest; "
+                        "dropping new turn"
+                    )
 
     def _worker_loop(self) -> None:
         """Background drain loop. Entry point for self._sync_worker.
@@ -1002,11 +1013,10 @@ class CashewMemoryProvider(MemoryProvider):  # type: ignore[misc]
 
         user, assistant, session_id = turn
 
-        # Short-circuit if shutdown is in progress — the interpreter's atexit
-        # handlers may have already finalized the embedding model's thread pool,
-        # and calling end_session would raise RuntimeError from sentence-transformers.
+        # Short-circuit only after Python interpreter finalization has been
+        # observed. Normal provider shutdown must drain accepted turns.
         if self._shutdown_flag.is_set():
-            logger.debug("cashew sync: shutdown flag set, dropping turn")
+            logger.debug("cashew sync: interpreter shutdown flag set, dropping turn")
             return
 
         import sqlite3
@@ -1265,9 +1275,9 @@ class CashewMemoryProvider(MemoryProvider):  # type: ignore[misc]
     def on_session_end(self, messages: list) -> None:
         """Session boundary notification.
 
-        Does NOT drain the sync queue — the background worker is non-daemon and
-        keeps running across session boundaries. Data-loss protection is handled
-        by shutdown(), which posts a sentinel and bounded-joins the worker.
+        Does NOT drain the sync queue — the background worker keeps running across
+        session boundaries. Data-loss protection is handled by shutdown(), which
+        stops producers, posts a sentinel, and bounded-joins the worker.
 
         Sleep cycle processing is handled by a Hermes cron job.
         See ``sleep_schedule`` in cashew.json.
@@ -1292,19 +1302,20 @@ class CashewMemoryProvider(MemoryProvider):  # type: ignore[misc]
             return  # safe no-op: initialize() was never called
         _METRICS.emit()
         timeout = self._config.sync_queue_timeout if self._config is not None else 30.0
-        # Signal shutdown BEFORE the sentinel so _drain_once can short-circuit
-        # even if the sentinel is still queued behind pending turns.
-        self._shutdown_flag.set()
-        # Post sentinel. put_nowait first; if somehow full, try a brief blocking put.
-        try:
-            self._sync_queue.put_nowait(_SHUTDOWN)
-        except queue.Full:
+        # Atomically stop new producers and post the sentinel. Items already in
+        # the queue remain ahead of it and receive a bounded opportunity to
+        # persist before the worker exits.
+        with self._sync_state_lock:
+            self._shutdown_started.set()
             try:
-                self._sync_queue.put(_SHUTDOWN, block=True, timeout=1.0)
+                self._sync_queue.put_nowait(_SHUTDOWN)
             except queue.Full:
-                logger.warning(
-                    "cashew shutdown: could not post sentinel; worker may leak"
-                )
+                try:
+                    self._sync_queue.put(_SHUTDOWN, block=True, timeout=1.0)
+                except queue.Full:
+                    logger.warning(
+                        "cashew shutdown: could not post sentinel; worker may leak"
+                    )
         # Bounded join. Never raise.
         if self._sync_worker is not None:
             self._sync_worker.join(timeout=timeout)

--- a/plugins/memory/cashew/__init__.py
+++ b/plugins/memory/cashew/__init__.py
@@ -377,9 +377,8 @@ class CashewMemoryProvider(MemoryProvider):  # type: ignore[misc]
         # Serializes producer admission with sentinel insertion so no turn can
         # race behind the shutdown sentinel and remain unprocessed.
         self._sync_state_lock = threading.Lock()
-        # Non-daemon worker that drains _sync_queue. Started in
-        # initialize() only on happy path. Joined in shutdown()
-        # with bounded timeout.
+        # Daemon worker that drains _sync_queue. Started in initialize() only
+        # on the happy path and given a bounded drain during shutdown().
         self._dropped_turn_count: int = 0
         # Monotonic counter of drop-oldest events on the sync queue.
         # Incremented inside sync_turn's overflow branch each time a queued
@@ -1293,7 +1292,9 @@ class CashewMemoryProvider(MemoryProvider):  # type: ignore[misc]
           2. Post _SHUTDOWN sentinel to the queue. put_nowait first; fallback to
              a 1s blocking put if the queue is full (worker is draining fast).
           3. Bounded-join the worker using sync_queue_timeout. WARNING on timeout.
-          4. Clear _sync_queue, _sync_worker, _config, _db_path, _retriever.
+          4. Clear runtime state after the worker exits. If the bounded join
+             times out, a daemon cleanup watcher retains that state until the
+             worker actually finishes.
 
         _hermes_home is intentionally NOT reset — is_available() must keep
         reflecting on-disk reality.
@@ -1302,42 +1303,68 @@ class CashewMemoryProvider(MemoryProvider):  # type: ignore[misc]
             return  # safe no-op: initialize() was never called
         _METRICS.emit()
         timeout = self._config.sync_queue_timeout if self._config is not None else 30.0
-        # Atomically stop new producers and post the sentinel. Items already in
-        # the queue remain ahead of it and receive a bounded opportunity to
-        # persist before the worker exits.
+        # Atomically stop new producers and capture the queue. Release the lock
+        # before the potentially blocking sentinel fallback: producers will see
+        # _shutdown_started and return without waiting on a full queue.
         with self._sync_state_lock:
             self._shutdown_started.set()
+            q = self._sync_queue
+            assert q is not None
+        # Items already in the queue remain ahead of the sentinel and receive a
+        # bounded opportunity to persist before the worker exits.
+        try:
+            q.put_nowait(_SHUTDOWN)
+        except queue.Full:
             try:
-                self._sync_queue.put_nowait(_SHUTDOWN)
+                q.put(_SHUTDOWN, block=True, timeout=1.0)
             except queue.Full:
-                try:
-                    self._sync_queue.put(_SHUTDOWN, block=True, timeout=1.0)
-                except queue.Full:
-                    logger.warning(
-                        "cashew shutdown: could not post sentinel; worker may leak"
-                    )
+                logger.warning(
+                    "cashew shutdown: could not post sentinel; worker may leak"
+                )
         # Bounded join. Never raise.
-        if self._sync_worker is not None:
-            self._sync_worker.join(timeout=timeout)
-            if self._sync_worker.is_alive():
+        worker = self._sync_worker
+        if worker is not None:
+            worker.join(timeout=timeout)
+            if worker.is_alive():
                 logger.warning(
                     "cashew sync worker did not exit within %ss; abandoning",
                     timeout,
                 )
-        # Sleep cycle cron job is intentionally NOT removed here.
-        # It persists across session boundaries so the 12h schedule
-        # isn't reset on every session start. The next initialize()
-        # will adopt the existing job if one exists.
-        self._sleep_cron_job_id = None  # clear instance tracking only
-        # Clear state. _hermes_home persists (see is_available() contract).
-        self._sync_queue = None
-        self._sync_worker = None
-        self._config = None
-        self._db_path = None
-        self._retriever = None
-        self._warm_cache.clear()
-        self._prefetch_pending = None
-        self._last_assistant = ""
+                cleanup = threading.Thread(
+                    target=self._clear_state_after_worker_exit,
+                    args=(worker,),
+                    daemon=True,
+                    name=f"cashew-shutdown-{self._session_id}",
+                )
+                cleanup.start()
+                return
+        self._clear_runtime_state(worker)
+
+    def _clear_state_after_worker_exit(self, worker: threading.Thread) -> None:
+        """Keep worker dependencies alive until a timed-out drain completes."""
+        worker.join()
+        self._clear_runtime_state(worker)
+
+    def _clear_runtime_state(self, worker: threading.Thread | None) -> None:
+        """Clear provider state if it still belongs to the exiting worker."""
+        with self._sync_state_lock:
+            if worker is not None and self._sync_worker is not worker:
+                return
+            # Sleep cycle cron job is intentionally NOT removed here.
+            # It persists across session boundaries so the 12h schedule
+            # isn't reset on every session start. The next initialize()
+            # will adopt the existing job if one exists.
+            self._sleep_cron_job_id = None  # clear instance tracking only
+            # Clear state. _hermes_home persists (see is_available() contract).
+            self._sync_queue = None
+            self._sync_worker = None
+            self._config = None
+            self._db_path = None
+            self._retriever = None
+            self._model_fn = None
+            self._warm_cache.clear()
+            self._prefetch_pending = None
+            self._last_assistant = ""
         logger.debug("cashew provider shutdown complete")
 
     def _parallel_retrieve(

--- a/tests/test_sync_turn.py
+++ b/tests/test_sync_turn.py
@@ -55,6 +55,17 @@ def fake_end_session_slow(sleep_s: float) -> Any:
     return _fake
 
 
+def fake_end_session_blocked(started: threading.Event, release: threading.Event) -> Any:
+    """Block one worker call until the test explicitly releases it."""
+
+    def _fake(*args: Any, **kwargs: Any) -> Any:
+        started.set()
+        assert release.wait(timeout=2.0)
+        return types.SimpleNamespace(new_nodes=[], new_edges=[], updated_nodes=[])
+
+    return _fake
+
+
 def make_initialized_provider(tmp_path) -> CashewMemoryProvider:
     p = CashewMemoryProvider()
     p.save_config({}, str(tmp_path))
@@ -68,25 +79,27 @@ def make_initialized_provider(tmp_path) -> CashewMemoryProvider:
 def test_sync_turn_enqueues_tuple(tmp_path, monkeypatch):
     """Pause the worker (slow mock); after sync_turn the queue contains one item."""
     # Use a very slow mock so the worker picks up the turn but stays busy
+    started = threading.Event()
+    release = threading.Event()
     monkeypatch.setattr(
-        "core.session.end_session", fake_end_session_slow(5.0), raising=False
+        "core.session.end_session",
+        fake_end_session_blocked(started, release),
+        raising=False,
     )
     p = make_initialized_provider(tmp_path)
     try:
         # First sync_turn — worker will pick it up (qsize goes to 0, but unfinished_tasks=1)
         # Use a second turn so qsize > 0
         p.sync_turn("u0", "a0")
-        time.sleep(0.05)  # let worker pick up the first turn
+        assert started.wait(timeout=1.0)
         p.sync_turn("u1", "a1")
         # Now the second turn is waiting in the queue (worker busy with first)
         assert p._sync_queue.qsize() == 1
     finally:
-        # Shrink shutdown budget so the 5s slow call doesn't block teardown
-        if p._config is not None:
-            p._config = dataclasses.replace(p._config, sync_queue_timeout=0.1)
         monkeypatch.setattr(
             "core.session.end_session", fake_end_session_ok([]), raising=False
         )
+        release.set()
         p.shutdown()
 
 
@@ -100,7 +113,7 @@ def test_sync_turn_fast_on_empty_queue(tmp_path, monkeypatch):
         start = time.monotonic()
         p.sync_turn("u", "a")
         elapsed = time.monotonic() - start
-        assert elapsed < 0.05, f"sync_turn blocked for {elapsed*1000:.1f}ms"
+        assert elapsed < 0.05, f"sync_turn blocked for {elapsed * 1000:.1f}ms"
     finally:
         p.shutdown()
 
@@ -134,7 +147,7 @@ def test_sync_turn_empty_queue_strict_15ms(tmp_path, monkeypatch):
         p.sync_turn("u", "a")
         elapsed = time.monotonic() - start
         assert elapsed < 0.015, (
-            f"sync_turn blocked for {elapsed*1000:.1f}ms; strict bound 15ms"
+            f"sync_turn blocked for {elapsed * 1000:.1f}ms; strict bound 15ms"
         )
     finally:
         p.shutdown()
@@ -142,29 +155,32 @@ def test_sync_turn_empty_queue_strict_15ms(tmp_path, monkeypatch):
 
 def test_sync_turn_fast_even_on_full_queue(tmp_path, monkeypatch):
     """Pitfall 5: sync_turn stays fast even when the queue is full (drop-oldest path)."""
+    started = threading.Event()
+    release = threading.Event()
     monkeypatch.setattr(
-        "core.session.end_session", fake_end_session_slow(100.0), raising=False
+        "core.session.end_session",
+        fake_end_session_blocked(started, release),
+        raising=False,
     )
     p = make_initialized_provider(tmp_path)
     try:
         # Fill to 16 — first turn picked up by worker (stuck), next 15 sit in queue
-        for i in range(16):
+        p.sync_turn("u0", "a0")
+        assert started.wait(timeout=1.0)
+        for i in range(1, 16):
             p.sync_turn(f"u{i}", f"a{i}")
         # Queue now likely full; next call must still be fast (drop-oldest path)
         start = time.monotonic()
         p.sync_turn("u17", "a17")
         elapsed = time.monotonic() - start
         assert elapsed < 0.05, (
-            f"sync_turn blocked for {elapsed*1000:.1f}ms on full queue — hot path violation"
+            f"sync_turn blocked for {elapsed * 1000:.1f}ms on full queue — hot path violation"
         )
     finally:
-        # Swap fake for fast so shutdown doesn't hang on the 100s sleep
         monkeypatch.setattr(
             "core.session.end_session", fake_end_session_ok([]), raising=False
         )
-        # Override config to cut shutdown timeout before join
-        if p._config is not None:
-            p._config = dataclasses.replace(p._config, sync_queue_timeout=0.1)
+        release.set()
         p.shutdown()
 
 
@@ -194,7 +210,7 @@ def test_drop_oldest_logs_warning_and_preserves_newest(tmp_path, monkeypatch, ca
             "core.session.end_session", fake_end_session_ok(calls), raising=False
         )
         if p._config is not None:
-            p._config = dataclasses.replace(p._config, sync_queue_timeout=0.2)
+            p._config = dataclasses.replace(p._config, sync_queue_timeout=1.0)
         p.shutdown()
 
 
@@ -232,8 +248,7 @@ def test_sync_turn_silent_noop_on_fresh_provider(caplog):
         p.sync_turn("u", "a")  # must not raise
     # No records at any level from sync_turn itself
     assert not caplog.records, (
-        f"fresh provider sync_turn logged: "
-        f"{[r.getMessage() for r in caplog.records]}"
+        f"fresh provider sync_turn logged: {[r.getMessage() for r in caplog.records]}"
     )
 
 

--- a/tests/test_sync_worker.py
+++ b/tests/test_sync_worker.py
@@ -114,9 +114,9 @@ def test_worker_processes_single_turn(tmp_path, monkeypatch):
     p = make_initialized_provider(tmp_path)
     try:
         p.sync_turn("hi", "hello")
-        assert drain_queue(
-            p, budget_s=2.0
-        ), f"drain timeout; unfinished={p._sync_queue.unfinished_tasks}"
+        assert drain_queue(p, budget_s=2.0), (
+            f"drain timeout; unfinished={p._sync_queue.unfinished_tasks}"
+        )
         assert len(calls) == 1
         assert calls[0]["session_id"] == "test-sync"
         assert calls[0]["conversation_text"] == "User: hi\nAssistant: hello"
@@ -160,9 +160,7 @@ def test_poisoned_turn_does_not_break_worker(tmp_path, monkeypatch, caplog):
             for i in range(16):
                 p.sync_turn(f"u{i}", f"a{i}")
             assert drain_queue(p, budget_s=3.0)
-        assert (
-            len(calls) == 16
-        ), f"expected all 16 turns attempted; got {len(calls)}"
+        assert len(calls) == 16, f"expected all 16 turns attempted; got {len(calls)}"
         # ONE WARNING from the poisoned turn
         worker_warnings = [
             r
@@ -193,13 +191,45 @@ def test_shutdown_posts_sentinel_and_joins(tmp_path, monkeypatch):
     baseline = threading.active_count()
     p = make_initialized_provider(tmp_path)
     p.shutdown()
-    assert wait_for_thread_exit(
-        baseline
-    ), f"thread leak: {threading.active_count()} vs {baseline}"
+    assert wait_for_thread_exit(baseline), (
+        f"thread leak: {threading.active_count()} vs {baseline}"
+    )
     assert p._sync_worker is None
     assert p._sync_queue is None
     assert p._config is None
     assert p._db_path is None
+
+
+def test_shutdown_drains_accepted_turns_and_rejects_new_ones(tmp_path, monkeypatch):
+    """Turns ahead of the sentinel persist; producers stop at shutdown start."""
+    first_started = threading.Event()
+    release_first = threading.Event()
+    calls: list[str] = []
+
+    def controlled_end_session(**kwargs):
+        calls.append(kwargs["conversation_text"])
+        if len(calls) == 1:
+            first_started.set()
+            assert release_first.wait(timeout=2.0)
+        return types.SimpleNamespace(new_nodes=[], new_edges=[], updated_nodes=[])
+
+    monkeypatch.setattr(
+        "core.session.end_session", controlled_end_session, raising=False
+    )
+    p = make_initialized_provider(tmp_path)
+    p.sync_turn("u1", "a1")
+    assert first_started.wait(timeout=1.0)
+    p.sync_turn("u2", "a2")
+
+    shutdown_thread = threading.Thread(target=p.shutdown)
+    shutdown_thread.start()
+    assert p._shutdown_started.wait(timeout=1.0)
+    p.sync_turn("u3", "a3")
+    release_first.set()
+    shutdown_thread.join(timeout=2.0)
+
+    assert not shutdown_thread.is_alive()
+    assert calls == ["User: u1\nAssistant: a1", "User: u2\nAssistant: a2"]
 
 
 def test_shutdown_hung_worker_logs_warning_no_raise(tmp_path, monkeypatch, caplog):
@@ -242,7 +272,7 @@ def test_shutdown_hung_worker_logs_warning_no_raise(tmp_path, monkeypatch, caplo
 def test_on_session_end_returns_without_draining_queue(tmp_path, monkeypatch):
     """on_session_end returns promptly without draining the sync queue.
 
-    The sync worker is non-daemon and keeps running across session boundaries.
+    The sync worker keeps running across session boundaries.
     Data-loss protection is handled by dispose(), not on_session_end.
     """
     monkeypatch.setattr(

--- a/tests/test_sync_worker.py
+++ b/tests/test_sync_worker.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import logging
+import queue
 import threading
 import time
 import types
@@ -259,6 +260,8 @@ def test_shutdown_hung_worker_logs_warning_no_raise(tmp_path, monkeypatch, caplo
             if r.levelname == "WARNING" and "did not exit within" in r.getMessage()
         ]
         assert len(hang_warnings) == 1
+        assert p._db_path is not None
+        assert p._config is not None
     finally:
         # Wait for the worker thread to exit (0.3s sleep completes, then
         # the worker returns to queue.get() and exits on sentinel). This
@@ -267,6 +270,29 @@ def test_shutdown_hung_worker_logs_warning_no_raise(tmp_path, monkeypatch, caplo
             f"hung worker did not exit within 1s budget: "
             f"active={threading.active_count()} baseline={baseline}"
         )
+        assert p._sync_worker is None
+        assert p._sync_queue is None
+        assert p._db_path is None
+        assert p._config is None
+
+
+def test_sync_turn_does_not_block_behind_full_queue_shutdown():
+    """A blocking sentinel fallback must not hold the producer lock."""
+    p = CashewMemoryProvider()
+    p._sync_queue = queue.Queue(maxsize=1)
+    p._sync_queue.put_nowait(("queued", "turn", "session"))
+
+    shutdown_thread = threading.Thread(target=p.shutdown)
+    shutdown_thread.start()
+    assert p._shutdown_started.wait(timeout=1.0)
+
+    start = time.monotonic()
+    p.sync_turn("late", "turn")
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 0.01
+    shutdown_thread.join(timeout=2.0)
+    assert not shutdown_thread.is_alive()
 
 
 def test_on_session_end_returns_without_draining_queue(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

<!-- 1-3 bullet points describing what this PR does and why -->

- Separate normal provider shutdown from unrecoverable Python interpreter finalization so accepted turns drain before the sentinel.
- Serialize producer admission with sentinel insertion, preventing a concurrent turn from landing behind the shutdown sentinel.
- Add a deterministic concurrency regression test proving accepted turns persist and late turns are rejected.

## Related Issues

<!-- Link to any related issues using Closes #N, Fixes #N, or similar -->

Closes #123

## Test Plan

<!-- How was this tested? Checklist of verification steps -->

- [x] Unit tests pass (`pytest`)
  - Full suite: 242 passed, 5 skipped.
- [x] New tests added for the change
- [x] Manual verification (describe what was tested)
  - Held the first extraction in flight, queued a second turn, started shutdown concurrently, attempted a third turn, and verified only the two pre-shutdown turns persisted in order.

## Breaking Changes

<!-- If this PR changes behavior, config keys, or API surfaces, describe what downstream consumers need to know -->

None. Shutdown now fulfills its documented bounded-drain contract; public APIs and configuration are unchanged.

## Notes for Reviewers

<!-- Anything reviewers should pay special attention to, architecture decisions made, trade-offs considered, etc. -->

Scope assessment: `sync_turn()` is the only producer for the provider queue and `shutdown()` is the only sentinel producer. `_sync_state_lock` therefore creates one admission boundary without involving the worker, while all queue operations remain non-blocking on the normal hot path. The existing interpreter-finalization handling remains separate and can still abandon work after sentence-transformers reports that Python's atexit sequence has begun.

Local gates: Ruff, mypy, deptry, duplicate detection, dead-flag detection, focused lifecycle/overflow tests, and the full suite passed. Graphify was refreshed after the code change.

Submitted by Codex (AI agent on behalf of Magnus Hedemark).
