### PR TITLE
fix(lifecycle): rebind switched sessions

### DIFF
--- a/plugins/memory/cashew/__init__.py
+++ b/plugins/memory/cashew/__init__.py
@@ -1284,6 +1284,23 @@ class CashewMemoryProvider(MemoryProvider):  # type: ignore[misc]
         if self._sync_queue is None:
             return  # not initialized or silent-degraded
 
+    def on_session_switch(
+        self,
+        new_session_id: str,
+        *,
+        parent_session_id: str = "",
+        reset: bool = False,
+        rewound: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        """Rebind session identity and discard ephemeral context from the old session."""
+        del parent_session_id, reset, rewound, kwargs
+        with self._sync_state_lock:
+            self._session_id = str(new_session_id)
+            self._warm_cache.clear()
+            self._prefetch_pending = None
+            self._last_assistant = ""
+
     def shutdown(self) -> None:
         """Post sentinel, bounded-join worker, clear references.
 

--- a/tests/test_session_switch.py
+++ b/tests/test_session_switch.py
@@ -1,0 +1,24 @@
+"""Hermes mid-process session-switch contract tests."""
+
+from plugins.memory.cashew import CashewMemoryProvider
+
+
+def test_session_switch_rebinds_identity_and_clears_ephemeral_context() -> None:
+    provider = CashewMemoryProvider()
+    provider._session_id = "session-a"
+    provider._warm_cache["old cue"] = "old context"
+    provider._prefetch_pending = "pending old context"
+    provider._last_assistant = "old assistant response"
+
+    provider.on_session_switch(
+        "session-b",
+        parent_session_id="session-a",
+        reset=False,
+        rewound=True,
+        future_contract_field="ignored",
+    )
+
+    assert provider._session_id == "session-b"
+    assert provider._warm_cache == {}
+    assert provider._prefetch_pending is None
+    assert provider._last_assistant == ""


### PR DESCRIPTION
Closes #124.\n\n## Summary\n- implement Hermes' on_session_switch lifecycle hook\n- rebind explicit extraction to the new session ID\n- clear warm-cache, pending-prefetch, and buffered-assistant state at the boundary\n- tolerate future Hermes keyword extensions\n\n## Verification\n- focused lifecycle/retrieval suite: 20 passed\n- suite excluding externally flaky real-home snapshot tests: 243 passed, 5 skipped\n- Ruff and mypy: clean