### PR TITLE
fix(config): enforce extraction and think switches

### DIFF
--- a/plugins/memory/cashew/__init__.py
+++ b/plugins/memory/cashew/__init__.py
@@ -701,7 +701,11 @@ class CashewMemoryProvider(MemoryProvider):  # type: ignore[misc]
 
         Half-state (_sync_queue is None) is a silent no-op.
         """
-        if not self._write_enabled:
+        if (
+            not self._write_enabled
+            or self._config is None
+            or not self._config.auto_extraction
+        ):
             return
         with self._sync_state_lock:
             if self._shutdown_started.is_set() or self._sync_queue is None:
@@ -1064,6 +1068,7 @@ class CashewMemoryProvider(MemoryProvider):  # type: ignore[misc]
         if (
             self._model_fn is not None
             and self._config
+            and self._config.think_cycles
             and self._config.think_interval > 0
         ):
             counter = self._load_think_counter() + 1

--- a/tests/test_sync_worker.py
+++ b/tests/test_sync_worker.py
@@ -3,6 +3,7 @@
 # Covers SYNC-02, SYNC-05, SYNC-06, ABC-05, ABC-06.
 from __future__ import annotations
 
+import dataclasses
 import logging
 import queue
 import threading
@@ -140,6 +141,41 @@ def test_worker_processes_multiple_turns_fifo(tmp_path, monkeypatch):
         assert len(calls) == 5
         for i, call in enumerate(calls):
             assert f"User: u{i}" in call["conversation_text"]
+    finally:
+        p.shutdown()
+
+
+def test_auto_extraction_false_does_not_enqueue_turn(tmp_path, monkeypatch):
+    calls: list[dict] = []
+    monkeypatch.setattr(
+        "core.session.end_session", fake_end_session_ok(calls), raising=False
+    )
+    p = make_initialized_provider(tmp_path)
+    try:
+        p._config = dataclasses.replace(p._config, auto_extraction=False)
+        p.sync_turn("private system input", "private system output")
+        assert p._sync_queue.unfinished_tasks == 0
+        assert calls == []
+    finally:
+        p.shutdown()
+
+
+def test_think_cycles_false_skips_periodic_think(tmp_path, monkeypatch):
+    think_calls: list[dict] = []
+    monkeypatch.setattr(
+        "core.session.end_session", fake_end_session_ok([]), raising=False
+    )
+    monkeypatch.setattr(
+        "core.session.think_cycle",
+        lambda **kwargs: think_calls.append(kwargs),
+        raising=False,
+    )
+    p = make_initialized_provider(tmp_path)
+    try:
+        p._config = dataclasses.replace(p._config, think_cycles=False, think_interval=1)
+        p._model_fn = lambda prompt: prompt
+        p._drain_once(("user", "assistant", "session"))
+        assert think_calls == []
     finally:
         p.shutdown()
 


### PR DESCRIPTION
Closes #126.\n\n## Summary\n- prevent queue admission when auto_extraction is disabled\n- require think_cycles before periodic think-cycle execution\n- add disabled-state runtime regression coverage for both switches\n\n## Verification\n- focused sync suite: 22 passed, 1 skipped\n- suite excluding externally noisy real-home snapshot tests: 251 passed, 5 skipped\n- Ruff and mypy: clean