### PR TITLE
fix(sleep): reconcile persistent cron state

### DIFF
--- a/plugins/memory/cashew/__init__.py
+++ b/plugins/memory/cashew/__init__.py
@@ -514,12 +514,7 @@ class CashewMemoryProvider(MemoryProvider):  # type: ignore[misc]
                 # Runs AFTER the sync worker so the provider is fully initialized
                 # before any background work begins. Silently skips when the
                 # Hermes cron module is not available (e.g. CI, standalone tests).
-                if (
-                    self._write_enabled
-                    and self._config.sleep_cycles
-                    and self._config.sleep_schedule
-                    and _HAS_HERMES_CRON
-                ):
+                if self._write_enabled and _HAS_HERMES_CRON:
                     self._register_sleep_cron()
                 set_plugin_context(
                     session_id=session_id,
@@ -564,64 +559,48 @@ class CashewMemoryProvider(MemoryProvider):  # type: ignore[misc]
     # ── Sleep cycle cron scheduling ──────────────────────────────────────
 
     def _register_sleep_cron(self) -> None:
-        """Install the cron script and register a no_agent cron job.
-
-        Called from initialize() only on the happy path.  Safe to call
-        multiple times — if a job is already registered for this provider
-        instance, the call is a no-op.
-
-        The cron job persists across session boundaries (survives shutdown)
-        so the 12h schedule isn't reset on every session start.
-        """
-        if self._sleep_cron_job_id is not None:
-            return  # already registered for this instance
-
+        """Reconcile the persistent cron job and managed script with config."""
         if self._hermes_home is None or self._config is None:
             return
-
-        # Scan for an existing sleep cron job by name.
-        # If one exists, adopt its ID and skip registration so the
-        # original 12h timer isn't reset. Without this, every session
-        # start would remove-and-re-register the job, resetting the
-        # schedule and preventing it from ever firing.
         try:
-            from cron.jobs import list_jobs
+            from cron.jobs import create_job, list_jobs, remove_job
 
-            for job in list_jobs():
-                if job.get("name") == "cashew-sleep-cycle":
-                    self._sleep_cron_job_id = job["id"]
-                    logger.info(
-                        "sleep: adopted existing cron job %s (preserving schedule)",
-                        job["id"],
-                    )
-                    return  # keep the existing job running
-        except ImportError:
-            logger.debug("sleep: cron module not available — cannot adopt")
-        except Exception:
-            logger.warning("sleep: failed to adopt existing cron job", exc_info=True)
+            existing = [
+                job for job in list_jobs() if job.get("name") == "cashew-sleep-cycle"
+            ]
+            desired_schedule = self._config.sleep_schedule
+            enabled = self._config.sleep_cycles and bool(desired_schedule)
+            if not enabled:
+                for job in existing:
+                    remove_job(job["id"])
+                self._sleep_cron_job_id = None
+                return
 
-        try:
-            # Read the cron script source from disk and install it.
             script_source = (
                 pathlib.Path(__file__).parent / "sleep_cron_script.py"
             ).read_text()
-
-            # Install the script to $HERMES_HOME/scripts/
             script_dest = self._hermes_home / "scripts" / "cashew-sleep-cycle.py"
             script_dest.parent.mkdir(parents=True, exist_ok=True)
-            if not script_dest.exists():
-                script_dest.write_text(script_source)
-                script_dest.chmod(0o755)
-                logger.info("sleep: installed cron script to %s", script_dest)
-            else:
-                logger.debug("sleep: cron script already exists at %s", script_dest)
+            if not script_dest.exists() or script_dest.read_text() != script_source:
+                staged = script_dest.with_suffix(".py.tmp")
+                staged.write_text(script_source)
+                staged.chmod(0o755)
+                staged.replace(script_dest)
+                logger.info("sleep: refreshed cron script at %s", script_dest)
 
-            # Register via the Hermes cron API.
-            from cron.jobs import create_job
+            matching = [
+                job for job in existing if job.get("schedule") == desired_schedule
+            ]
+            if len(existing) == 1 and len(matching) == 1:
+                self._sleep_cron_job_id = matching[0]["id"]
+                return
+
+            for job in existing:
+                remove_job(job["id"])
 
             job = create_job(
                 prompt="hermes-cashew sleep cycle",
-                schedule=self._config.sleep_schedule,
+                schedule=desired_schedule,
                 name="cashew-sleep-cycle",
                 script="cashew-sleep-cycle.py",
                 no_agent=True,
@@ -631,7 +610,7 @@ class CashewMemoryProvider(MemoryProvider):  # type: ignore[misc]
             logger.info(
                 "sleep: registered cron job %s (schedule=%s)",
                 job["id"],
-                self._config.sleep_schedule,
+                desired_schedule,
             )
         except ImportError:
             logger.warning(

--- a/tests/test_sleep_cron_reconcile.py
+++ b/tests/test_sleep_cron_reconcile.py
@@ -1,0 +1,84 @@
+"""Unit contracts for persistent sleep-cron desired-state reconciliation."""
+
+from __future__ import annotations
+
+import sys
+import types
+from dataclasses import replace
+from pathlib import Path
+
+from plugins.memory.cashew import CashewMemoryProvider
+from plugins.memory.cashew.config import CashewConfig
+
+
+def _install_fake_cron(monkeypatch, jobs: list[dict]):
+    removed: list[str] = []
+    created: list[dict] = []
+    package = types.ModuleType("cron")
+    package.__path__ = []
+    module = types.ModuleType("cron.jobs")
+    module.list_jobs = lambda: list(jobs)
+    module.remove_job = lambda job_id: removed.append(job_id)
+
+    def create_job(**kwargs):
+        created.append(kwargs)
+        return {"id": "replacement"}
+
+    module.create_job = create_job
+    monkeypatch.setitem(sys.modules, "cron", package)
+    monkeypatch.setitem(sys.modules, "cron.jobs", module)
+    return removed, created
+
+
+def _provider(tmp_path: Path, **changes) -> CashewMemoryProvider:
+    provider = CashewMemoryProvider()
+    provider._hermes_home = tmp_path
+    provider._config = replace(CashewConfig(), **changes)
+    return provider
+
+
+def test_disabled_sleep_removes_persisted_job(tmp_path, monkeypatch):
+    removed, created = _install_fake_cron(
+        monkeypatch,
+        [{"id": "old", "name": "cashew-sleep-cycle", "schedule": "every 12h"}],
+    )
+    provider = _provider(tmp_path, sleep_cycles=False)
+
+    provider._register_sleep_cron()
+
+    assert removed == ["old"]
+    assert created == []
+    assert provider._sleep_cron_job_id is None
+
+
+def test_schedule_change_replaces_job_and_refreshes_script(tmp_path, monkeypatch):
+    removed, created = _install_fake_cron(
+        monkeypatch,
+        [{"id": "old", "name": "cashew-sleep-cycle", "schedule": "every 12h"}],
+    )
+    script = tmp_path / "scripts" / "cashew-sleep-cycle.py"
+    script.parent.mkdir()
+    script.write_text("stale plugin code")
+    provider = _provider(tmp_path, sleep_schedule="every 6h")
+
+    provider._register_sleep_cron()
+
+    assert removed == ["old"]
+    assert created[0]["schedule"] == "every 6h"
+    assert provider._sleep_cron_job_id == "replacement"
+    packaged = Path(__file__).parents[1] / "plugins/memory/cashew/sleep_cron_script.py"
+    assert script.read_text() == packaged.read_text()
+
+
+def test_matching_job_is_adopted_without_reset(tmp_path, monkeypatch):
+    removed, created = _install_fake_cron(
+        monkeypatch,
+        [{"id": "current", "name": "cashew-sleep-cycle", "schedule": "every 12h"}],
+    )
+    provider = _provider(tmp_path)
+
+    provider._register_sleep_cron()
+
+    assert removed == []
+    assert created == []
+    assert provider._sleep_cron_job_id == "current"


### PR DESCRIPTION
Closes #129.\n\n## Summary\n- remove persisted jobs when sleep is disabled or schedule is empty\n- replace jobs when schedule changes and collapse duplicates\n- preserve a single matching job without resetting its timer\n- atomically refresh the managed cron script when packaged code changes\n- add direct desired-state reconciliation tests\n\n## Verification\n- focused cron suite: 4 passed\n- suite excluding externally noisy real-home snapshot tests: 256 passed, 5 skipped\n- Ruff and mypy: clean