### PR TITLE
fix(logging): redact memory query content

### DIFF
--- a/plugins/memory/cashew/__init__.py
+++ b/plugins/memory/cashew/__init__.py
@@ -1463,16 +1463,20 @@ class CashewMemoryProvider(MemoryProvider):  # type: ignore[misc]
                     continue
                 cue_lower = cue.lower()
                 if cue_lower in query_lower or query_lower in cue_lower:
-                    logger.info("prefetch warm cache HIT: cue=%r query=%r", cue, query)
+                    logger.info(
+                        "prefetch warm cache HIT: cue_len=%d query_len=%d",
+                        len(cue),
+                        len(query),
+                    )
                     self._warm_cache.clear()
                     return ctx
                 cue_words = set(w for w in cue_lower.split() if len(w) > 3)
                 query_words = set(w for w in query_lower.split() if len(w) > 3)
                 if len(cue_words & query_words) >= 2:
                     logger.info(
-                        "prefetch warm cache HIT: cue=%r query=%r (word overlap)",
-                        cue,
-                        query,
+                        "prefetch warm cache HIT: cue_len=%d query_len=%d (word overlap)",
+                        len(cue),
+                        len(query),
                     )
                     self._warm_cache.clear()
                     return ctx
@@ -1526,7 +1530,7 @@ class CashewMemoryProvider(MemoryProvider):  # type: ignore[misc]
                     return self._format_context(nodes)
             except Exception:
                 logger.warning(
-                    "cashew recall failed for query=%r", query, exc_info=True
+                    "cashew recall failed (query_len=%d)", len(query), exc_info=True
                 )
         return ""
 

--- a/plugins/memory/cashew/log_filter.py
+++ b/plugins/memory/cashew/log_filter.py
@@ -1,8 +1,8 @@
 """Log scrubbing filter for the cashew memory provider.
 
-Redacts sensitive values (API keys, tokens, user message content) from log
-output via a standard library logging.Filter.  Also provides a utility to
-install the filter on a logger instance.
+Redacts credential-shaped values and bounds log-message length via a standard
+library logging.Filter. Call sites must never pass ordinary user content: a
+generic logging filter cannot reliably distinguish it from operational text.
 """
 
 from __future__ import annotations

--- a/tests/test_query_log_privacy.py
+++ b/tests/test_query_log_privacy.py
@@ -1,0 +1,46 @@
+"""Privacy contracts for memory-query operational logging."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+from plugins.memory.cashew import CashewMemoryProvider
+from plugins.memory.cashew.config import CashewConfig
+
+
+def _provider() -> CashewMemoryProvider:
+    provider = CashewMemoryProvider()
+    provider._config = CashewConfig()
+    provider._db_path = MagicMock()
+    return provider
+
+
+def test_warm_cache_hit_logs_lengths_not_query_content(caplog):
+    sensitive = "HIV treatment plan for Alice"
+    provider = _provider()
+    provider._warm_cache[sensitive] = "private context"
+
+    with caplog.at_level(logging.INFO, logger="plugins.memory.cashew"):
+        assert provider.prefetch(sensitive) == "private context"
+
+    assert sensitive not in caplog.text
+    assert "Alice" not in caplog.text
+    assert f"query_len={len(sensitive)}" in caplog.text
+
+
+def test_recall_failure_logs_length_not_query_content(caplog, monkeypatch):
+    sensitive = "bankruptcy filing for Robert"
+    provider = _provider()
+    monkeypatch.setattr(
+        provider,
+        "_keyword_search",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("failure")),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="plugins.memory.cashew"):
+        assert provider.prefetch(sensitive) == ""
+
+    assert sensitive not in caplog.text
+    assert "Robert" not in caplog.text
+    assert f"query_len={len(sensitive)}" in caplog.text


### PR DESCRIPTION
Closes #131.\n\n## Summary\n- remove raw query and cue values from cache-hit logs\n- remove raw query values from recall-failure logs\n- log only lengths needed for operational diagnosis\n- clarify that generic secret scrubbing cannot identify arbitrary user content\n- add sensitive non-credential regression cases\n\n## Verification\n- focused privacy/retrieval suite: 20 passed\n- suite excluding externally noisy real-home snapshot tests: 260 passed, 5 skipped\n- Ruff and mypy: clean