### PR TITLE
fix(plugin): align manifest dependency bounds

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -6,7 +6,7 @@ name: cashew
 version: 0.10.2
 description: "Cashew — persistent thought-graph memory with local embeddings, organic decay, and autonomous think cycles."
 pip_dependencies:
-  - "cashew-brain"
+  - "cashew-brain>=1.1.0,<2.0.0"
   - "sqlite-vec"
 requires_env: []
 hooks:

--- a/plugins/memory/cashew/plugin.yaml
+++ b/plugins/memory/cashew/plugin.yaml
@@ -6,7 +6,7 @@ name: cashew
 version: 0.10.2
 description: "Cashew — persistent thought-graph memory with local embeddings, organic decay, and autonomous think cycles."
 pip_dependencies:
-  - "cashew-brain"
+  - "cashew-brain>=1.1.0,<2.0.0"
   - "sqlite-vec"
 requires_env: []
 hooks:

--- a/tests/test_manifest_dependencies.py
+++ b/tests/test_manifest_dependencies.py
@@ -1,0 +1,18 @@
+"""Installation surfaces must resolve the same runtime dependency contracts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import tomllib
+import yaml
+
+
+def test_plugin_manifests_match_project_runtime_dependencies() -> None:
+    root = Path(__file__).parents[1]
+    project = tomllib.loads((root / "pyproject.toml").read_text())
+    expected = set(project["project"]["dependencies"])
+
+    for relative in ("plugin.yaml", "plugins/memory/cashew/plugin.yaml"):
+        manifest = yaml.safe_load((root / relative).read_text())
+        assert set(manifest["pip_dependencies"]) == expected


### PR DESCRIPTION
Closes #132.\n\n## Summary\n- encode the supported cashew-brain range in both Hermes manifests\n- add a parity test comparing complete manifest dependency sets with pyproject metadata\n\n## Verification\n- manifest parity test: 1 passed\n- suite excluding externally noisy real-home snapshot tests: 261 passed, 5 skipped\n- Ruff: clean