### PR TITLE
fix(tools): expose query domain and tag filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,8 @@ Expected output shows `Provider: cashew` with `Plugin: installed` and `Status: a
 `hermes-cashew` provides two LLM-accessible tools:
 
 - **`cashew_query`** — searches the local thought graph for context relevant to
-  the current conversation. Uses sqlite-vec for semantic search.
+  the current conversation. Uses sqlite-vec for semantic search; optional
+  `domain`, `tag`, and `exclude_tags` filters narrow the result set.
 - **`cashew_extract`** — explicitly persists a conversation turn into the graph.
   The agent can call this when it judges a turn contains worth-remembering knowledge.
 

--- a/plugins/memory/cashew/tools.py
+++ b/plugins/memory/cashew/tools.py
@@ -19,6 +19,7 @@ Contract:
   - Extract envelopes do NOT echo user/assistant content — the LLM already has
     both strings in its context.
 """
+
 from __future__ import annotations
 
 import json
@@ -60,6 +61,16 @@ CASHEW_QUERY_SCHEMA: dict[str, Any] = {
                 "minimum": 1,
                 "maximum": 20,
             },
+            "domain": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Optional node domain to include (for example, 'work').",
+            },
+            "tag": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Optional tag that returned nodes must contain.",
+            },
             "exclude_tags": {
                 "type": "array",
                 "items": {"type": "string"},
@@ -92,13 +103,15 @@ def build_success_envelope(query: str, context: str, node_count: int) -> str:
     Shape:
         {"ok": true, "tool": "cashew_query", "query": ..., "context": ..., "node_count": N}
     """
-    return json.dumps({
-        "ok": True,
-        "tool": TOOL_NAME,
-        "query": query,
-        "context": context,
-        "node_count": node_count,
-    })
+    return json.dumps(
+        {
+            "ok": True,
+            "tool": TOOL_NAME,
+            "query": query,
+            "context": context,
+            "node_count": node_count,
+        }
+    )
 
 
 def build_error_envelope(
@@ -121,12 +134,14 @@ def build_error_envelope(
     Shape:
         {"ok": false, "tool": "cashew_query", "error": ..., "query": ...}
     """
-    return json.dumps({
-        "ok": False,
-        "tool": TOOL_NAME,
-        "error": error_message,
-        "query": query,
-    })
+    return json.dumps(
+        {
+            "ok": False,
+            "tool": TOOL_NAME,
+            "error": error_message,
+            "query": query,
+        }
+    )
 
 
 EXTRACT_TOOL_NAME: str = "cashew_extract"
@@ -181,12 +196,14 @@ def build_extract_success_envelope(new_nodes: int, new_edges: int) -> str:
     Shape:
         {"ok": true, "tool": "cashew_extract", "new_nodes": N, "new_edges": M}
     """
-    return json.dumps({
-        "ok": True,
-        "tool": EXTRACT_TOOL_NAME,
-        "new_nodes": new_nodes,
-        "new_edges": new_edges,
-    })
+    return json.dumps(
+        {
+            "ok": True,
+            "tool": EXTRACT_TOOL_NAME,
+            "new_nodes": new_nodes,
+            "new_edges": new_edges,
+        }
+    )
 
 
 def build_extract_error_envelope(error_message: str = "cashew extract failed") -> str:
@@ -209,8 +226,10 @@ def build_extract_error_envelope(error_message: str = "cashew extract failed") -
     echo user/assistant content — the LLM already has both strings in its
     context.
     """
-    return json.dumps({
-        "ok": False,
-        "tool": EXTRACT_TOOL_NAME,
-        "error": error_message,
-    })
+    return json.dumps(
+        {
+            "ok": False,
+            "tool": EXTRACT_TOOL_NAME,
+            "error": error_message,
+        }
+    )

--- a/tests/test_tool_schema.py
+++ b/tests/test_tool_schema.py
@@ -79,9 +79,15 @@ def test_valid_args_pass_jsonschema_validation():
     jsonschema = pytest.importorskip("jsonschema")
     jsonschema.validate({"query": "hello"}, CASHEW_QUERY_SCHEMA["parameters"])
     jsonschema.validate(
-        {"query": "hello", "max_nodes": 5},
+        {"query": "hello", "max_nodes": 5, "domain": "work", "tag": "project:x"},
         CASHEW_QUERY_SCHEMA["parameters"],
     )
+
+
+def test_schema_exposes_implemented_positive_filters():
+    props = CASHEW_QUERY_SCHEMA["parameters"]["properties"]
+    assert props["domain"]["type"] == "string"
+    assert props["tag"]["type"] == "string"
 
 
 def test_missing_query_fails_jsonschema_validation():
@@ -121,5 +127,9 @@ def test_provider_get_tool_schemas_returns_single_cashew_query_schema():
     callers must not mutate them.
     """
     schemas = CashewMemoryProvider().get_tool_schemas()
-    assert len(schemas) == 2, "Phase 4 expects two schemas: cashew_query + cashew_extract"
-    assert schemas[0] is CASHEW_QUERY_SCHEMA, "get_tool_schemas must return the module constant, not a copy"
+    assert len(schemas) == 2, (
+        "Phase 4 expects two schemas: cashew_query + cashew_extract"
+    )
+    assert schemas[0] is CASHEW_QUERY_SCHEMA, (
+        "get_tool_schemas must return the module constant, not a copy"
+    )


### PR DESCRIPTION
Closes #133.\n\n## Summary\n- declare implemented domain and tag filters in CASHEW_QUERY_SCHEMA\n- validate both as non-empty strings\n- align root documentation with the handler and plugin README\n- cover the filters in Draft 7 schema validation\n\n## Verification\n- focused schema/handler suite: 25 passed\n- suite excluding externally noisy real-home snapshot tests: 263 passed, 5 skipped\n- Ruff: clean