### PR TITLE
fix(config): preserve Hermes YAML on bootstrap

### DIFF
--- a/plugins/memory/cashew/__init__.py
+++ b/plugins/memory/cashew/__init__.py
@@ -7,6 +7,7 @@ import os
 import pathlib
 import queue
 import sqlite3
+import tempfile
 import threading
 import time
 from typing import Any, Callable, Dict, List
@@ -194,17 +195,37 @@ def _ensure_auxiliary_memory(hermes_home: pathlib.Path) -> None:
     if base_url:
         memory_config["base_url"] = base_url
 
-    if "auxiliary" not in data:
-        data["auxiliary"] = {}
-    data["auxiliary"]["memory"] = memory_config
-
     try:
-        config_path.write_text(
-            yaml.safe_dump(
-                data, default_flow_style=False, sort_keys=False, allow_unicode=True
-            ),
-            encoding="utf-8",
-        )
+        if "auxiliary" in data:
+            from utils import atomic_roundtrip_yaml_update
+
+            atomic_roundtrip_yaml_update(config_path, "auxiliary.memory", memory_config)
+        else:
+            fragment = yaml.safe_dump(
+                {"auxiliary": {"memory": memory_config}},
+                default_flow_style=False,
+                sort_keys=False,
+                allow_unicode=True,
+            )
+            separator = "" if not raw or raw.endswith("\n\n") else "\n"
+            updated = raw + separator + fragment
+            mode = config_path.stat().st_mode
+            fd, staged_name = tempfile.mkstemp(
+                dir=config_path.parent,
+                prefix=".config_",
+                suffix=".yaml.tmp",
+            )
+            staged = pathlib.Path(staged_name)
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                    handle.write(updated)
+                    handle.flush()
+                    os.fsync(handle.fileno())
+                staged.chmod(mode)
+                staged.replace(config_path)
+            except BaseException:
+                staged.unlink(missing_ok=True)
+                raise
         logger.info(
             "auto-populated auxiliary.memory from main model config: "
             "provider=%s model=%s",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,6 @@ known_first_party = ["plugins"]
 package_module_name_map = { "opentelemetry-api" = "opentelemetry" }
 
 [tool.deptry.per_rule_ignores]
-DEP001 = ["cashew-brain", "sqlite-vec", "agent", "cron", "cashew_sleep_refactor", "_hermes_cashew_impl", "opentelemetry-api", "sentry-sdk"]
+DEP001 = ["cashew-brain", "sqlite-vec", "agent", "cron", "utils", "cashew_sleep_refactor", "_hermes_cashew_impl", "opentelemetry-api", "sentry-sdk"]
 DEP002 = ["pytest", "pytest-cov", "pytest-asyncio", "pytest-mock", "build", "ruff", "mypy", "pre-commit", "vulture", "deptry", "jsonschema", "opentelemetry-api", "sentry-sdk"]
 DEP003 = ["numpy", "sklearn", "sentence_transformers", "httpx", "yaml"]

--- a/tests/test_initialize_lifecycle.py
+++ b/tests/test_initialize_lifecycle.py
@@ -317,6 +317,30 @@ def test_ensure_auxiliary_memory_populates_from_main_model(tmp_path):
     assert aux_memory["base_url"] == "https://openrouter.ai/api/v1"
 
 
+def test_ensure_auxiliary_memory_preserves_user_yaml_text_and_mode(tmp_path):
+    from plugins.memory.cashew import _ensure_auxiliary_memory
+
+    config_yaml = tmp_path / "config.yaml"
+    original = (
+        "# keep this comment\n"
+        "model:\n"
+        "  provider: 'openrouter'  # preserve quotes\n"
+        "  default: &chosen 'openrouter/auto'\n"
+        "display:\n"
+        "  selected: *chosen\n"
+    )
+    config_yaml.write_text(original)
+    config_yaml.chmod(0o640)
+
+    _ensure_auxiliary_memory(tmp_path)
+
+    updated = config_yaml.read_text()
+    assert updated.startswith(original)
+    assert "# keep this comment" in updated
+    assert "&chosen 'openrouter/auto'" in updated
+    assert config_yaml.stat().st_mode & 0o777 == 0o640
+
+
 def test_ensure_auxiliary_memory_does_not_overwrite_existing(tmp_path):
     """_ensure_auxiliary_memory never overwrites existing auxiliary.memory."""
     from plugins.memory.cashew import _ensure_auxiliary_memory


### PR DESCRIPTION
Closes #135.\n\n## Summary\n- append a validated auxiliary.memory fragment without reserializing user YAML\n- use Hermes' comment-preserving round-trip API for an existing auxiliary mapping\n- write through fsync plus atomic replacement\n- preserve original file permissions\n- cover comments, quotes, anchors, aliases, text prefix, and mode\n\n## Verification\n- focused initialization suite: 20 passed\n- suite excluding externally noisy real-home snapshot tests: 264 passed, 5 skipped\n- Ruff and mypy: clean