### PR TITLE
fix(sleep): declare direct runtime dependencies

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -7,6 +7,9 @@ version: 0.10.2
 description: "Cashew — persistent thought-graph memory with local embeddings, organic decay, and autonomous think cycles."
 pip_dependencies:
   - "cashew-brain>=1.1.0,<2.0.0"
+  - "numpy"
+  - "scikit-learn"
+  - "sentence-transformers"
   - "sqlite-vec"
 requires_env: []
 hooks:

--- a/plugins/memory/cashew/plugin.yaml
+++ b/plugins/memory/cashew/plugin.yaml
@@ -7,6 +7,9 @@ version: 0.10.2
 description: "Cashew — persistent thought-graph memory with local embeddings, organic decay, and autonomous think cycles."
 pip_dependencies:
   - "cashew-brain>=1.1.0,<2.0.0"
+  - "numpy"
+  - "scikit-learn"
+  - "sentence-transformers"
   - "sqlite-vec"
 requires_env: []
 hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,9 @@ requires-python = ">=3.10"
 authors = [{ name = "Magnus Hedemark", email = "magnus919@pm.me" }]
 dependencies = [
     "cashew-brain>=1.1.0,<2.0.0",
+    "numpy",
+    "scikit-learn",
+    "sentence-transformers",
     "sqlite-vec",
 ]
 
@@ -111,4 +114,4 @@ package_module_name_map = { "opentelemetry-api" = "opentelemetry" }
 [tool.deptry.per_rule_ignores]
 DEP001 = ["cashew-brain", "sqlite-vec", "agent", "cron", "utils", "cashew_sleep_refactor", "_hermes_cashew_impl", "opentelemetry-api", "sentry-sdk"]
 DEP002 = ["pytest", "pytest-cov", "pytest-asyncio", "pytest-mock", "build", "ruff", "mypy", "pre-commit", "vulture", "deptry", "jsonschema", "opentelemetry-api", "sentry-sdk"]
-DEP003 = ["numpy", "sklearn", "sentence_transformers", "httpx", "yaml"]
+DEP003 = ["httpx", "yaml"]

--- a/tests/test_manifest_dependencies.py
+++ b/tests/test_manifest_dependencies.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import tomllib
@@ -16,3 +17,14 @@ def test_plugin_manifests_match_project_runtime_dependencies() -> None:
     for relative in ("plugin.yaml", "plugins/memory/cashew/plugin.yaml"):
         manifest = yaml.safe_load((root / relative).read_text())
         assert set(manifest["pip_dependencies"]) == expected
+
+
+def test_sleep_cycle_dependencies_are_direct_project_requirements() -> None:
+    root = Path(__file__).parents[1]
+    project = tomllib.loads((root / "pyproject.toml").read_text())
+    dependency_names = {
+        re.match(r"[A-Za-z0-9_.-]+", dependency).group()
+        for dependency in project["project"]["dependencies"]
+    }
+
+    assert {"numpy", "scikit-learn", "sentence-transformers"} <= dependency_names


### PR DESCRIPTION
## Summary

- Declare NumPy, scikit-learn, and sentence-transformers as direct sleep-cycle runtime dependencies.
- Keep both plugin manifests aligned, and replace the now-unneeded deptry suppressions with a regression test.

## Related Issues

Closes #154

## Test Plan

- [ ] Full local `pytest` suite is not green: a live `~/.hermes` cron output changed the real-home snapshot test, and a separate timing-sensitive worker test failed. CI remains required.
- [x] New regression test fails on `origin/main` and passes on this branch.
- [x] Focused dependency tests, Ruff, mypy, vulture, duplicate/flag checks, and deptry pass.
- [x] Built a wheel, installed it into a fresh Python 3.11 environment, and imported `run_sleep_cycle`.

## Breaking Changes

None

## Notes for Reviewers

The direct-dependency test scores 6/8 on the project test-quality rubric: it uses real project metadata with no mocks, private state, or conditional assertions. The full suite needs CI confirmation because the local host has unrelated, active Hermes processes.

Submitted by Jasper (AI agent on behalf of Magnus Hedemark).
